### PR TITLE
New Regex to find arbitrary number of links

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -30,21 +30,28 @@ body {
   background-color: #e22434;
   height: 33px;
   width: 33px;
+  border-style: solid;
+  border-radius: 1px;
+  border-color: #8F8F9D;
   margin: 3px 10px;
+  padding: 0px;
 }
 
 input[type="checkbox"] {
   background-color: #e22434;
   border: 0px;
 }
+
 input[type="number"] {
   background-color: #ffffff;
-  border: 0px;
-  padding: 0px;
   font-size: 20px;
   text-align: center;
   -moz-appearance:textfield; /* Firefox */
+  -webkit-box-sizing: border-box; /* Safari/Chrome, other WebKit */
+  -moz-box-sizing: border-box;    /* Firefox, other Gecko */
+  box-sizing: border-box;         /* Opera/IE 8+ */
 }
+
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
     display: none;
@@ -65,6 +72,16 @@ input {
   margin-top: -20px;
   vertical-align: middle;
   white-space: nowrap;
+}
+
+.numberinput span {
+  display: inline-block;
+  margin-top: -10px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.numberinput img {
+  margin-bottom: -8px;
 }
 
 .socket-size {

--- a/src/index.css
+++ b/src/index.css
@@ -26,10 +26,31 @@ body {
   padding-top: 20px;
 }
 
+.numberinput-input {
+  background-color: #e22434;
+  height: 33px;
+  width: 33px;
+  margin: 3px 10px;
+}
+
 input[type="checkbox"] {
   background-color: #e22434;
   border: 0px;
 }
+input[type="number"] {
+  background-color: #ffffff;
+  border: 0px;
+  padding: 0px;
+  font-size: 20px;
+  text-align: center;
+  -moz-appearance:textfield; /* Firefox */
+}
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+    display: none;
+    margin: 0;
+}
+
 input[type="search"] {
   background-color: #ffffff;
 }

--- a/src/pages/Vendor.tsx
+++ b/src/pages/Vendor.tsx
@@ -183,9 +183,11 @@ const Vendor = () => {
                     
                     <div className="column-header small-padding"> Other Links</div>
                     <Checkbox label="Enable (Can Be long)" value={specLink} onChange={setSpecLink}/>
-                    <NumberInput label="Red Links" value={specLinkColorsR} onChange={setSpecLinkColorsR}/>
-                    <NumberInput label="Green Links" value={specLinkColorsG} onChange={setSpecLinkColorsG}/>
-                    <NumberInput label="Blue Links" value={specLinkColorsB} onChange={setSpecLinkColorsB}/>
+                    <div>
+                    <NumberInput label="r" value={specLinkColorsR} image="r" onChange={setSpecLinkColorsR}/>
+                    <NumberInput label="g" value={specLinkColorsG} image="g" onChange={setSpecLinkColorsG}/>
+                    <NumberInput label="b" value={specLinkColorsB} image="b" onChange={setSpecLinkColorsB}/>
+                    </div>
                     
                 </div>
                 <div className="item">
@@ -231,6 +233,7 @@ interface LinkCheckboxProps {
 interface NumberInputProps {
     label: string
     value: number
+    image?: string
     onChange: Dispatch<SetStateAction<number>>
     className?: string
 }
@@ -266,12 +269,11 @@ const SocketCheckbox = (props: LinkCheckboxProps) => {
 
 export const NumberInput = (props: NumberInputProps) => {
     return (
-        <div className={props.className}>
-            <label className="numberinput">
-                <input className="numberinput-input" type="number" min="0" max="6" value={props.value} onChange={e => props.onChange(Number(e.target.value))}/>
-                <span>{props.label}</span>
-            </label>
-        </div>
+        <label className="numberinput">
+            <input className="numberinput-input" placeholder="0" type="number" min="0" max="6" value={props.value} onChange={e => props.onChange(Number(e.target.value))}/>
+            {props.image ? <img className="socket-size" src={imgFromChar(props.image)} alt="red"/> : null}
+            <span>&nbsp;{props.label}</span>
+        </label>
     );
 }
 

--- a/src/pages/Vendor.tsx
+++ b/src/pages/Vendor.tsx
@@ -45,6 +45,11 @@ const Vendor = () => {
     const [gr, setGr] = React.useState(hasNKey(savedSettings, "colors.gr"));
     const [bg, setBg] = React.useState(hasNKey(savedSettings, "colors.bg"));
 
+    const [specLink, setSpecLink] = React.useState(hasNKey(savedSettings, "colors.specLink"));
+    const [specLinkColorsR, setSpecLinkColorsR] = React.useState(hasNKey(savedSettings, "colors.specLinkColors.r") ? savedSettings["colors.specLinkColors.r"] : 0);
+    const [specLinkColorsG, setSpecLinkColorsG] = React.useState(hasNKey(savedSettings, "colors.specLinkColors.g") ? savedSettings["colors.specLinkColors.g"] : 0);
+    const [specLinkColorsB, setSpecLinkColorsB] = React.useState(hasNKey(savedSettings, "colors.specLinkColors.b") ? savedSettings["colors.specLinkColors.b"] : 0);
+
     const [anyThreeLink, setAnyThreeLink] = React.useState(hasNKey(savedSettings, "anyThreeLink"));
     const [anyFourLink, setAnyFourLink] = React.useState(hasNKey(savedSettings, "anyFourLink"));
     const [movement10, setMovement10] = React.useState(hasNKey(savedSettings, "movement.ten"));
@@ -67,6 +72,7 @@ const Vendor = () => {
         setRrr, setGgg, setBbb,
         setRrA, setGgA, setBbA, setRrg, setRrb, setGgr, setGgb, setBbr, setBbg, setRgb, setRaa, setGaa, setBaa,
         setRr, setGg, setBb, setRb, setGr, setBg,
+        setSpecLink, setSpecLinkColorsR, setSpecLinkColorsG, setSpecLinkColorsB,
         setAnyThreeLink, setAnyFourLink,
         setMovement10, setMovement15, setLightning,
         setFire, setCold, setPhys, setChaos, setAnyGem,
@@ -76,6 +82,7 @@ const Vendor = () => {
         rrr, ggg, bbb,
         rrA, ggA, bbA, rrg, rrb, ggr, ggb, bbr, bbg, rgb, raa, gaa, baa,
         rr, gg, bb, rb, gr, bg,
+        specLink, specLinkColorsR, specLinkColorsG, specLinkColorsB,
         anyThreeLink, anyFourLink,
         movement10, movement15, lightning,
         fire, cold, phys, chaos, anyGem,
@@ -95,6 +102,12 @@ const Vendor = () => {
             ggr, ggb, rrg, rrb, bbg, bbr,
             rgb, raa, gaa, baa,
             rr, gg, bb, rb, gr, bg,
+            specLink,
+            specLinkColors : {
+                r: specLinkColorsR,
+                g: specLinkColorsG,
+                b: specLinkColorsB,
+            }
         },
         plusGems: {
             lightning,
@@ -167,6 +180,13 @@ const Vendor = () => {
                     <SocketCheckbox className="small-padding" label="r-b" value={rb} onChange={setRb}/>
                     <SocketCheckbox label="g-r" value={gr} onChange={setGr}/>
                     <SocketCheckbox label="b-g" value={bg} onChange={setBg}/>
+                    
+                    <div className="column-header small-padding"> Other Links</div>
+                    <Checkbox label="Enable (Can Be long)" value={specLink} onChange={setSpecLink}/>
+                    <NumberInput label="Red Links" value={specLinkColorsR} onChange={setSpecLinkColorsR}/>
+                    <NumberInput label="Green Links" value={specLinkColorsG} onChange={setSpecLinkColorsG}/>
+                    <NumberInput label="Blue Links" value={specLinkColorsB} onChange={setSpecLinkColorsB}/>
+                    
                 </div>
                 <div className="item">
                     <div className="column-header">
@@ -208,6 +228,13 @@ interface LinkCheckboxProps {
     className?: string
 }
 
+interface NumberInputProps {
+    label: string
+    value: number
+    onChange: Dispatch<SetStateAction<number>>
+    className?: string
+}
+
 export const Checkbox = (props: CheckboxProps) => {
     return (
         <div className={props.className}>
@@ -232,6 +259,17 @@ const SocketCheckbox = (props: LinkCheckboxProps) => {
                 <span className="link-text">
                 {props.label.replaceAll("-", "")}
                 </span>
+            </label>
+        </div>
+    );
+}
+
+export const NumberInput = (props: NumberInputProps) => {
+    return (
+        <div className={props.className}>
+            <label className="numberinput">
+                <input className="numberinput-input" type="number" min="0" max="6" value={props.value} onChange={e => props.onChange(Number(e.target.value))}/>
+                <span>{props.label}</span>
             </label>
         </div>
     );

--- a/src/utils/OutputString.test.ts
+++ b/src/utils/OutputString.test.ts
@@ -53,6 +53,10 @@ function getDefaultSettings(): PoeStringSettings {
             rgb: false, raa: false, gaa: false, baa: false,
             rr: false, gg: false, bb: false,
             rb: false, gr: false, bg: false,
+            specLink: false,
+            specLinkColors : {
+                r: 0, g: 0, b: 0
+            }
         },
         plusGems: {
             lightning: false,

--- a/src/utils/OutputString.ts
+++ b/src/utils/OutputString.ts
@@ -34,6 +34,13 @@ export interface PoeStringSettings {
         rb: boolean
         gr: boolean
         bg: boolean
+
+        specLink: boolean
+        specLinkColors: {
+            r: number,
+            g: number,
+            b: number
+        }
     }
     plusGems: {
         lightning: boolean
@@ -54,6 +61,7 @@ export interface PoeStringSettings {
 export function generateResultString(settings: PoeStringSettings): string {
     let result = ""
     result = addExpression(result, generate4LinkStr(settings));
+    result = addExpression(result, generateSpecLinkStr(settings));
     result = addExpression(result, simplify(generate3LinkStr(settings)));
     result = addExpression(result, generate2Link(settings));
     result = addExpression(result, movementStr(settings));
@@ -98,6 +106,26 @@ export function generate3LinkStr(settings: PoeStringSettings): string {
 }
 
 export function generate4LinkStr(settings: PoeStringSettings): string {
+    if(!settings.colors.specLink)
+        return "";
+    const {r, g, b} = settings.colors.specLinkColors;
+    if(r === 0 && g === 0 && b === 0)
+        return "";
+    const lastColor = (b === 0 && g === 0) ? "r" : (b === 0 ? "g" : "b");
+    let result = "ts:.+";
+    if(r > 0){
+        result += lastColor==="r" ? `(\\S*r){${r}}` : `(?=(\\S*r){${r}})`
+    }
+    if(g > 0){
+        result += lastColor==="g" ? `(\\S*g){${g}}` : `(?=(\\S*g){${g}})`
+    }
+    if(b > 0){
+        result += `(\\S*b){${b}}`
+    }
+    return result;
+}
+
+export function generateSpecLinkStr(settings: PoeStringSettings): string {
     return settings.anyFourLink ? "-[rgb]-.-" : "";
 }
 

--- a/src/utils/OutputString.ts
+++ b/src/utils/OutputString.ts
@@ -106,6 +106,10 @@ export function generate3LinkStr(settings: PoeStringSettings): string {
 }
 
 export function generate4LinkStr(settings: PoeStringSettings): string {
+    return settings.anyFourLink ? "-[rgb]-.-" : "";
+}
+
+export function generateSpecLinkStr(settings: PoeStringSettings): string {
     if(!settings.colors.specLink)
         return "";
     const {r, g, b} = settings.colors.specLinkColors;
@@ -123,10 +127,6 @@ export function generate4LinkStr(settings: PoeStringSettings): string {
         result += `(\\S*b){${b}}`
     }
     return result;
-}
-
-export function generateSpecLinkStr(settings: PoeStringSettings): string {
-    return settings.anyFourLink ? "-[rgb]-.-" : "";
 }
 
 function oneAndAnyAny(c: string): string {


### PR DESCRIPTION
This adds a new option suggested by https://github.com/veiset/poe-vendor-string/issues/25
It dynamically creates the regex with the suggested shortening of the regex if one of the values is 0.
From my very limited testing this seems to work, however it very quickly creates lines that are >50 Characters.

![New Layout](https://user-images.githubusercontent.com/9990060/185301525-1174f3b5-4dee-4fe0-b032-259bf94265b4.png)

I'm not a Webdev, so this needs some fixing on the css side of things.
Also please let me know if on the react side of thing there are things to improve

This does not implement the 3 or 4 Link Regex changes that were suggested. 