### PR TITLE
Add new Regexes for 5 and 6 Links and shortening of 4 Link

### DIFF
--- a/src/pages/Vendor.tsx
+++ b/src/pages/Vendor.tsx
@@ -226,7 +226,7 @@ export const Checkbox = (props: CheckboxProps) => {
 }
 
 const SocketCheckbox = (props: LinkCheckboxProps) => {
-    const els = props.link !== undefined ? props.link.split("") : props.label.split("");
+    const els = props.link?.split("") ?? props.label.split("");
 
     return (
         <div className={props.className}>

--- a/src/pages/Vendor.tsx
+++ b/src/pages/Vendor.tsx
@@ -47,6 +47,8 @@ const Vendor = () => {
 
     const [anyThreeLink, setAnyThreeLink] = React.useState(hasNKey(savedSettings, "anyThreeLink"));
     const [anyFourLink, setAnyFourLink] = React.useState(hasNKey(savedSettings, "anyFourLink"));
+    const [anyFiveLink, setAnyFiveLink] = React.useState(hasNKey(savedSettings, "anyFiveLink"));
+    const [anySixLink, setAnySixLink] = React.useState(hasNKey(savedSettings, "anySixLink"));
     const [movement10, setMovement10] = React.useState(hasNKey(savedSettings, "movement.ten"));
     const [movement15, setMovement15] = React.useState(hasNKey(savedSettings, "movement.fifteen"));
 
@@ -67,7 +69,7 @@ const Vendor = () => {
         setRrr, setGgg, setBbb,
         setRrA, setGgA, setBbA, setRrg, setRrb, setGgr, setGgb, setBbr, setBbg, setRgb, setRaa, setGaa, setBaa,
         setRr, setGg, setBb, setRb, setGr, setBg,
-        setAnyThreeLink, setAnyFourLink,
+        setAnyThreeLink, setAnyFourLink, setAnyFiveLink, setAnySixLink,
         setMovement10, setMovement15, setLightning,
         setFire, setCold, setPhys, setChaos, setAnyGem,
         setDmgPhys, setDmgElemental, setDmgSpellFlat, setDmgSpell
@@ -76,7 +78,7 @@ const Vendor = () => {
         rrr, ggg, bbb,
         rrA, ggA, bbA, rrg, rrb, ggr, ggb, bbr, bbg, rgb, raa, gaa, baa,
         rr, gg, bb, rb, gr, bg,
-        anyThreeLink, anyFourLink,
+        anyThreeLink, anyFourLink, anyFiveLink, anySixLink,
         movement10, movement15, lightning,
         fire, cold, phys, chaos, anyGem,
         dmgPhys, dmgElemental, dmgSpellFlat, dmgSpell
@@ -85,6 +87,8 @@ const Vendor = () => {
     let settings: PoeStringSettings = {
         anyThreeLink,
         anyFourLink,
+        anyFiveLink,
+        anySixLink,
         movement: {
             ten: movement10,
             fifteen: movement15,
@@ -156,6 +160,8 @@ const Vendor = () => {
                     <Checkbox label="Movement speed (15%)" value={movement15} onChange={setMovement15}/>
 
                     <div className="column-header"> Any links</div>
+                    <Checkbox label="Any 6 link" value={anySixLink} onChange={setAnySixLink}/>
+                    <SocketCheckbox label="Any 5 link" value={anyFiveLink} onChange={setAnyFiveLink} link="*-*-*-*-*"/>
                     <SocketCheckbox label="Any 4 link" value={anyFourLink} onChange={setAnyFourLink} link="*-*-*-*"/>
                     <SocketCheckbox label="Any 3 link" value={anyThreeLink} onChange={setAnyThreeLink} link="*-*-*"/>
 

--- a/src/pages/Vendor.tsx
+++ b/src/pages/Vendor.tsx
@@ -160,11 +160,11 @@ const Vendor = () => {
                     <Checkbox label="Movement speed (15%)" value={movement15} onChange={setMovement15}/>
 
                     <div className="column-header"> Any links</div>
-                    <Checkbox label="Any 6 link" value={anySixLink} onChange={setAnySixLink}/>
-                    <SocketCheckbox label="Any 5 link" value={anyFiveLink} onChange={setAnyFiveLink} link="*-*-*-*-*"/>
-                    <SocketCheckbox label="Any 4 link" value={anyFourLink} onChange={setAnyFourLink} link="*-*-*-*"/>
                     <SocketCheckbox label="Any 3 link" value={anyThreeLink} onChange={setAnyThreeLink} link="*-*-*"/>
-
+                    <SocketCheckbox label="Any 4 link" value={anyFourLink} onChange={setAnyFourLink} link="*-*-*-*"/>
+                    <SocketCheckbox label="Any 5 link" value={anyFiveLink} onChange={setAnyFiveLink} link="*-*-*-*-*"/>
+                    <SocketCheckbox label="Any 6 link" value={anySixLink} onChange={setAnySixLink} link=""/>
+                    
                     <div className="column-header small-padding"> Link colors (2L)</div>
                     <SocketCheckbox label="r-r" value={rr} onChange={setRr}/>
                     <SocketCheckbox label="g-g" value={gg} onChange={setGg}/>
@@ -226,7 +226,7 @@ export const Checkbox = (props: CheckboxProps) => {
 }
 
 const SocketCheckbox = (props: LinkCheckboxProps) => {
-    const els = props.link ? props.link.split("") : props.label.split("");
+    const els = props.link !== undefined ? props.link.split("") : props.label.split("");
 
     return (
         <div className={props.className}>

--- a/src/utils/OutputString.test.ts
+++ b/src/utils/OutputString.test.ts
@@ -45,6 +45,8 @@ function getDefaultSettings(): PoeStringSettings {
     return {
         anyThreeLink: false,
         anyFourLink: false,
+        anyFiveLink: false,
+        anySixLink: false,
         movement: {ten: false, fifteen: false,},
         colors: {
             rrr: false, ggg: false, bbb: false,

--- a/src/utils/OutputString.ts
+++ b/src/utils/OutputString.ts
@@ -1,6 +1,8 @@
 export interface PoeStringSettings {
     anyThreeLink: boolean
     anyFourLink: boolean
+    anyFiveLink: boolean
+    anySixLink: boolean
     movement: {
         ten: boolean
         fifteen: boolean
@@ -54,6 +56,8 @@ export interface PoeStringSettings {
 export function generateResultString(settings: PoeStringSettings): string {
     let result = ""
     result = addExpression(result, generate4LinkStr(settings));
+    result = addExpression(result, generate5LinkStr(settings));
+    result = addExpression(result, generate6LinkStr(settings));
     result = addExpression(result, simplify(generate3LinkStr(settings)));
     result = addExpression(result, generate2Link(settings));
     result = addExpression(result, movementStr(settings));
@@ -74,7 +78,7 @@ export function generate3LinkStr(settings: PoeStringSettings): string {
     const {rrr, ggg, bbb, rrg, rrb, ggr, ggb, bbr, bbg, rgb, rrA, ggA, bbA, raa, baa, gaa} = colors;
 
     let result = "";
-    if (settings.anyThreeLink) result = addExpression(result, "-[rgb]-");
+    if (settings.anyThreeLink) {result = addExpression(result, "-\\w-"); return result};
     if (rrr) result = addExpression(result, "r-r-r");
     if (ggg) result = addExpression(result, "g-g-g");
     if (bbb) result = addExpression(result, "b-b-b");
@@ -98,7 +102,15 @@ export function generate3LinkStr(settings: PoeStringSettings): string {
 }
 
 export function generate4LinkStr(settings: PoeStringSettings): string {
-    return settings.anyFourLink ? "-[rgb]-.-" : "";
+    return settings.anyFourLink ? "-\\w-.-" : "";
+}
+
+export function generate5LinkStr(settings: PoeStringSettings): string {
+    return settings.anyFiveLink ? "(-\\w){4}" : "";
+}
+
+export function generate6LinkStr(settings: PoeStringSettings): string {
+    return settings.anySixLink ? "(-\\w){5}" : "";
 }
 
 function oneAndAnyAny(c: string): string {


### PR DESCRIPTION
This commits adds the Regexes suggested by https://github.com/veiset/poe-vendor-string/issues/25 to add 5 and 6 link regexes and improve the old regexes

Note that I had to change the generate3LinkStr function because due to the change, the simplifyRGB function doesn't find the new regex.
I'm not sure if that could possible hurt regex length in any way.

Also one Problem in the new Layout is that the 6 Link Image would be too big. I'm not sure how you can fix that, so I just left it out for 6 Links.
![new Layout](https://user-images.githubusercontent.com/9990060/185308377-975c5886-1931-4210-99c7-9501b3e9b218.png)

