### PR TITLE
Fix map page pack size input id being non-unique

### DIFF
--- a/src/pages/maps/Maps.tsx
+++ b/src/pages/maps/Maps.tsx
@@ -61,8 +61,8 @@ const Maps = () => {
                 <label className="modifier-search-label" htmlFor="quantity">Quantity of at least</label>
                 <input type="search" className="modifier-quantity-box" id="quantity" name="search-mod" value={quantity}
                        onChange={v => setQuantity(v.target.value)}/>
-                <label className="modifier-search-label" htmlFor="quantity">Pack Size of at least</label>
-                <input type="search" className="modifier-quantity-box" id="quantity" name="search-mod" value={packsize}
+                <label className="modifier-search-label" htmlFor="pack-size">Pack Size of at least</label>
+                <input type="search" className="modifier-quantity-box" id="pack-size" name="search-mod" value={packsize}
                        onChange={v => setPacksize(v.target.value)}/>
                 <Checkbox label="Optimize Quantity value (round down to nearest 10, saves a lot of query space)" value={optimizeQuant}
                           onChange={setOptimizeQuant}/>


### PR DESCRIPTION
This fixes a copy-paste error in the "Pack Size of at least" input field on the Map page where it had a duplicate ID with the "Quantity of at least" input field. This can confuse accessibility technologies that rely on the `htmlFor` properties on the corresponding labels. I didn't catch any other obvious issues in a cursory accessibility sweep.