### PR TITLE
beast regex: fix diseased arachnid

### DIFF
--- a/src/generated/GeneratedBeastRegex.ts
+++ b/src/generated/GeneratedBeastRegex.ts
@@ -61,7 +61,7 @@ export const beastRegex: BeastRegex[] = [
   { beast: "Cursed Spawn", recipe: "", regex: "sed s"},
   { beast: "Devourer", recipe: "", regex: "Devourer"},
   { beast: "Dirt Scrabbler", recipe: "", regex: "rt s"},
-  { beast: "Diseased Arachnid", recipe: "", regex: "sed ar"},
+  { beast: "Diseased Arachnid", recipe: "", regex: "sed ara"},
   { beast: "Dread Primate", recipe: "", regex: "ad p"},
   { beast: "Dune Hellion", recipe: "", regex: "ne h"},
   { beast: "Dust Scrabbler", recipe: "", regex: "ust s"},


### PR DESCRIPTION
This commit changes the regex for diseased arachnid from "sed ar" to "sed ara", because "sed ar" incorrectly matches yellow beasts with "increased area of effect" modifiers.