### PR TITLE
fix fire / cold multi and shorten mods

### DIFF
--- a/src/utils/OutputString.ts
+++ b/src/utils/OutputString.ts
@@ -352,7 +352,7 @@ export function generateWeaponDamage(settings: PoeStringSettings): string {
     if (phys) result = addExpression(result, "Glint|Heav");
     if (firemult) result = addExpression(result, "Earn");
     if (coldmult) result = addExpression(result, "Incl");
-    if (chaosmult) result = addExpression(result, "Wani"); 
+    if (chaosmult) result = addExpression(result, "Wani");
 
     return result;
 }

--- a/src/utils/OutputString.ts
+++ b/src/utils/OutputString.ts
@@ -350,9 +350,9 @@ export function generateWeaponDamage(settings: PoeStringSettings): string {
     const {phys, firemult, coldmult, chaosmult} = settings.damage;
     let result = "";
     if (phys) result = addExpression(result, "Glint|Heav");
-    if (firemult) result = addExpression(result, "Inclement");
-    if (coldmult) result = addExpression(result, "Earnest");
-    if (chaosmult) result = addExpression(result, "Waning");
+    if (firemult) result = addExpression(result, "Earn");
+    if (coldmult) result = addExpression(result, "Incl");
+    if (chaosmult) result = addExpression(result, "Wani"); 
 
     return result;
 }


### PR DESCRIPTION
The fire / cold multi mod names ended up swapped.

I also shortened them based on the shortest string that only matched those at https://www.pathofexile.com/item-data/mods, but I don't know if this is exhaustive. I did a quick test at Nessa just to verify it didn't match random bases and it looked okay, but if there's a better way to verify this just let me know and I'll do it :)