### PR TITLE
Make regex result visible on small screens

### DIFF
--- a/src/components/ResultBox.css
+++ b/src/components/ResultBox.css
@@ -5,6 +5,10 @@
     color: white;
     flex-wrap: nowrap;
     flex-direction: row;
+
+    @media (max-width: 800px) {
+        flex-direction: column;
+    }
 }
 .result {
     padding: 30px;
@@ -14,7 +18,19 @@
     flex-shrink: 10;
     flex-grow: 0;
     text-overflow: ellipsis;
-    overflow: hidden;
+    overflow-y: hidden;
+    overflow-x: scroll;
+
+    > span {
+        @media (max-width: 800px) {
+            white-space: nowrap;
+        }
+    }
+
+    @media (max-width: 800px) {
+        padding: 30px 8px;
+        text-overflow: clip;
+    }
 }
 .result-action {
     width: 196px;

--- a/src/components/ResultBox.tsx
+++ b/src/components/ResultBox.tsx
@@ -26,7 +26,7 @@ const ResultBox = (props: ResultBoxProps) => {
     return (
         <div className="row result-box">
             <div className={result.length > maxLength ? "result" : result === copied ? "result copied-good" : "result"}>
-                {result}
+                <span>{result}</span>
                 {result.length > maxLength && <div className="error">Error: more than 50 characters, cannot be used in the PoE client</div>}
                 {!error && result.length <= maxLength && result.length > 0 && <div className="size-info">length: {result.length} / 50</div>}
                 {error && <div className="error">Error: {error}</div>}


### PR DESCRIPTION
Now the regex is possible to see also on mobile devices. If the regex is long, it will be horizontally scrollable. It should not break, since that would make it hard to know if there is whitespace involved.

Fixes #48


Screenshot from Firefox's emulated iPhone SE 2nd gen (375 px wide):

<img width="377" alt="image" src="https://github.com/veiset/poe-vendor-string/assets/4339443/673d39d6-b610-4ce4-a5da-c1a45148c546">

scrolled:

<img width="384" alt="image" src="https://github.com/veiset/poe-vendor-string/assets/4339443/576a647e-7255-4e5a-b9b4-d1660be03f72">

iPhone 12 Pro Max
<img width="428" alt="image" src="https://github.com/veiset/poe-vendor-string/assets/4339443/24eecc34-4531-490e-b650-e3f455900ebe">


iPad (810 px wide):
<img width="818" alt="image" src="https://github.com/veiset/poe-vendor-string/assets/4339443/d036096c-8283-47a3-a7a5-1e97ab293e79">
