### PR TITLE
Add regex entry for Unidentified Maps in generated map modifiers

### DIFF
--- a/src/generated/GeneratedMapModsRegular.ts
+++ b/src/generated/GeneratedMapModsRegular.ts
@@ -85,6 +85,7 @@ export const regexMapModifiersRegular: Regex<MapModifiersRegularTokenOption> = {
     {id: 2023345436, regex: "itc", rawText: "Area is inhabited by Sea Witches and their Spawn", generalizedText: "^area is inhabited by sea witches and their spawn$", options: {tier17: false, scary: 4}},
     {id: 2042799595, regex: "ety", rawText: "Area has increased monster variety", generalizedText: "^area has increased monster variety$", options: {tier17: false, scary: 8}},
     {id: 2043204851, regex: "d at", rawText: "Unique Boss deals 25% increased Damage|Unique Boss has 30% increased Attack and Cast Speed", generalizedText: "^unique boss deals #% increased damage$|^unique boss has #% increased attack and cast speed$", options: {tier17: false, scary: 420}},
+    {id: 2084106149, regex: "ide", rawText: "Unidentified Maps", generalizedText: "^unidentified maps$", options: {tier17: false, scary: 0}},
   ],
   optimizationTable: {
     "-2103899765:-1462808973": {ids: [-2103899765, -1462808973], regex: "ik", weight: 2, count: 2},


### PR DESCRIPTION
Adding new entry to the `regexMapModifiersRegular` tokens list for handling **Unidentified Maps**. The new entry includes the following details:

- **ID**: `2084106149`
- **Regex**: `"ide"` 
- **Raw Text**: `"Unidentified Maps"`
- **Generalized Text**: `"^unidentified maps$"`
- **Options**: `{tier17: false, scary: 0}`

Currently, when using the regex, unidentified maps are matched by existing filters, even though they should not be selected. This change introduces a new filter specifically for unidentified maps, ensuring they are excluded from selection during processing. This addition prevents unintended behavior and improves the accuracy of the regex logic.

![Example of Unidentified Map](https://i.imgur.com/94t0DZB.png)