### PR TITLE
Increase default maxLength in RegexResultBox from 50 to 250

### DIFF
--- a/src/components/RegexResultBox/RegexResultBox.tsx
+++ b/src/components/RegexResultBox/RegexResultBox.tsx
@@ -27,7 +27,7 @@ const RegexResultBox = (props: RegexResultBoxProps) => {
     maxLength
   } = props;
 
-  const maxLen = maxLength ?? 50;
+  const maxLen = maxLength ?? 250;
   const [showOptions, setShowOptions] = useState(false);
   const [copied, setCopied] = React.useState<string | undefined>(undefined);
   const [autoCopy, setAutoCopy] = React.useState(false);

--- a/src/components/ResultBox.tsx
+++ b/src/components/ResultBox.tsx
@@ -12,7 +12,7 @@ export interface ResultBoxProps {
 
 const ResultBox = (props: ResultBoxProps) => {
   const {result, warning, error, reset} = props;
-  const maxLength = props.maxLength || 50;
+  const maxLength = props.maxLength || 250;
 
   const [copied, setCopied] = React.useState<string | undefined>(undefined);
   const [autoCopy, setAutoCopy] = React.useState(false);


### PR DESCRIPTION
According to new [QOL announcement](https://youtu.be/WjQtB2gFEro?si=hayJYdzVFn1HtDHl&t=92) GGG is increasing the search bar max length from 50 to 250. 

To follow with that, I decided to make this small PR to change this limit. Still draft just because it lacks on in-game testing. Since we don't know if the menagerie limit was increased or not. And it's also good to test others since ~~we~~ I don't know if all seach boxes uses the same code base or even if they changed all of them. even though it seems pretty obvious