### PR TITLE
Fix magic item open suffix issues

### DIFF
--- a/src/pages/magicitem/MagicItemOutput.ts
+++ b/src/pages/magicitem/MagicItemOutput.ts
@@ -1,7 +1,7 @@
 import {ItemSettings} from "../../utils/SavedSettings";
 import {ItemAffixRegex} from "../../generated/GeneratedMagicItem";
 
-const openSuffix = (numOfWords: number) => `^(\\w+ ){${numOfWords}}\\w+$`;
+const openSuffix = (numOfWords: number) => `^([\\w-']+ ){${numOfWords}}\\w+$`;
 const openPrefix = (numOfWords: number) => `^(\\w+.){${numOfWords}}\\sof`;
 
 export const generateMagicItemRegex = (settings: ItemSettings) => {


### PR DESCRIPTION
Prefixes that have an apostrophe or names that have an apostrophe, for example Two-Stone rings, break the open suffix regex because it won't match on apostrophes or hyphens.

This fixes the issue by adding apostrophes and hyphens to the match token list in the openSuffix check.

Closes: #206 #207 