### PR TITLE
Fix bug report URL encoding causing HTTP 400

### DIFF
--- a/src/components/bugreport/BugReport.tsx
+++ b/src/components/bugreport/BugReport.tsx
@@ -7,11 +7,14 @@ interface BugreportPros {
 export const BugReport = (props: BugreportPros) => {
   const {regex} = props;
   const site = window.location.hash.replace("#/", "");
+  
+  const title = `[Bug,${site}]: "${regex.slice(0, 250)}"`;
+  const encodedTitle = encodeURIComponent(title);
 
   return (<a
     className="bug-report"
     target="_blank"
-    href={`https://github.com/veiset/poe-vendor-string/issues/new?template=bug-report.md&title=[Bug,${site}]:%20${regex.slice(0, 250)}`}>
+    href={`https://github.com/veiset/poe-vendor-string/issues/new?template=bug-report.md&title=${encodedTitle}`}>
     <svg xmlns="http://www.w3.org/2000/svg" height="1em" fill="currentColor" viewBox="0 0 512 512"
          className="bug-report-icon">
       <path


### PR DESCRIPTION
## Summary
Fixes an issue where the "Report a Bug" button returns an HTTP 400 error.

## Root Cause
The `title` query parameter was not properly URL-encoded. Regex strings may contain special characters like `%`, `|`, or `[` which break the URL.

## Fix
Use `encodeURIComponent` to properly encode the full title string before appending it to the GitHub URL.

## Before
Malformed URLs caused HTTP 400 errors.

## After
Valid GitHub issue URLs are generated for all regex inputs.