### PR TITLE
Fix auto-copy: use finalResult and gate copied state on success

### DIFF
--- a/src/components/RegexResultBox/RegexResultBox.test.tsx
+++ b/src/components/RegexResultBox/RegexResultBox.test.tsx
@@ -1,0 +1,55 @@
+import React, {useState} from "react";
+import {render, screen, fireEvent, waitFor} from "@testing-library/react";
+import RegexResultBox from "./RegexResultBox";
+
+const Harness = () => {
+  const [customText, setCustomText] = useState("foo");
+  const [enableCustomText, setEnableCustomText] = useState(true);
+  return (
+    <RegexResultBox
+      result="bar"
+      reset={() => {}}
+      customText={customText}
+      setCustomText={setCustomText}
+      enableCustomText={enableCustomText}
+      setEnableCustomText={setEnableCustomText}
+    />
+  );
+};
+
+const enableAutoCopy = () => {
+  fireEvent.click(screen.getByRole("button", {name: /options/i}));
+  fireEvent.click(screen.getByLabelText(/auto copy result text/i));
+};
+
+describe("RegexResultBox auto-copy", () => {
+  let writeTextMock: jest.Mock;
+
+  beforeEach(() => {
+    writeTextMock = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: {writeText: writeTextMock},
+      configurable: true,
+    });
+  });
+
+  test("writes finalResult and marks copied once on success", async () => {
+    render(<Harness />);
+    enableAutoCopy();
+
+    expect(writeTextMock).toHaveBeenCalledWith("bar foo");
+    await waitFor(() => expect(screen.getByText("bar foo")).toHaveClass("copied-good"));
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not mark copied when writeText rejects", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("Clipboard write is not allowed"));
+
+    render(<Harness />);
+    enableAutoCopy();
+
+    expect(writeTextMock).toHaveBeenCalledWith("bar foo");
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText("bar foo")).not.toHaveClass("copied-good");
+  });
+});

--- a/src/components/RegexResultBox/RegexResultBox.tsx
+++ b/src/components/RegexResultBox/RegexResultBox.tsx
@@ -41,11 +41,13 @@ const RegexResultBox = (props: RegexResultBoxProps) => {
     : result;
 
   useEffect(() => {
-    if (autoCopy) {
-      navigator.clipboard.writeText(result);
-      setCopied(result);
-    }
-  }, [result, autoCopy]);
+    if (!autoCopy) return;
+    if (finalResult === copied) return;
+
+    navigator.clipboard.writeText(finalResult)
+      .then(() => setCopied(finalResult))
+      .catch(() => { /* permission denied; retry on next change */ });
+  }, [finalResult, autoCopy, copied]);
 
   return (
     <div className="rrb-layout">


### PR DESCRIPTION
## Summary

Fix the auto-copy effect in `RegexResultBox` so it copies `finalResult`
(which includes `customText` when enabled) instead of the bare `result`.
Bug present since 34b3c4d (Sep 2024): the display and the manual Copy
button already used `finalResult`, only auto-copy was left behind, so
users with both "Auto copy result text" and "Enable custom text" on
silently lost the custom suffix on the clipboard.

Also: `setCopied` is now inside the `writeText` `.then()` so the green
"copied" badge can't lie if the clipboard write rejects.

## Test plan

- [ ] Enable "Custom text" + "Auto copy result text", paste elsewhere → clipboard contains regex + custom text.
- [ ] Manual Copy button still copies (bare and with custom text).