### PR TITLE
fix(rate-limit): add KV caching for search results based on regex

### DIFF
--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -50,10 +50,11 @@ const OptimizedMapMods = () => {
         quantity,
         packsize,
         itemRarity,
+        regex: result,
       };
       const tradeResult = await openTradeSearch(settings);
       if (tradeResult.success) {
-        setTradeMessage(`Trade search opened! Found ${tradeResult.total ?? 0} results.`);
+        setTradeMessage("Trade search opened!");
       } else {
         setTradeMessage(`Trade site opened. ${tradeResult.error ? `(${tradeResult.error})` : ''}`);
       }

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -4,8 +4,6 @@ const WORKER_URL = "https://poe-trade-proxy.veiset.workers.dev";
 const TRADE_URL_BASE = "https://www.pathofexile.com/trade/search";
 
 interface WorkerSearchResponse {
-  id: string;
-  total: number;
   url: string;
   error?: string;
 }
@@ -23,6 +21,7 @@ export interface TradeSettings {
   quantity: string;
   packsize: string;
   itemRarity: string;
+  regex: string;
 }
 
 interface TradeQuery {
@@ -53,8 +52,6 @@ interface TradeQuery {
 export interface TradeSearchResult {
   success: boolean;
   url: string;
-  searchId?: string;
-  total?: number;
   error?: string;
 }
 
@@ -67,7 +64,8 @@ export async function getCurrentLeague(): Promise<string> {
 
   try {
     const response = await fetch(`${WORKER_URL}/leagues`);
-    if (!response.ok) throw new Error(`Failed to fetch leagues: ${response.status}`);
+    if (!response.ok)
+      throw new Error(`Failed to fetch leagues: ${response.status}`);
 
     const data: { result: { id: string }[] } = await response.json();
 
@@ -89,9 +87,9 @@ export async function getCurrentLeague(): Promise<string> {
 
 function toStatFilters(ids: number[]): { id: string }[] {
   return ids
-    .map(id => tradeStatMap[id.toString()])
+    .map((id) => tradeStatMap[id.toString()])
     .filter((statId): statId is string => statId !== undefined)
-    .map(id => ({ id }));
+    .map((id) => ({ id }));
 }
 
 function parseMinFilter(value: string): { min: number } | undefined {
@@ -165,7 +163,7 @@ export async function createTradeSearch(
     const response = await fetch(`${WORKER_URL}/search`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ league, query }),
+      body: JSON.stringify({ league, query, regex: settings.regex }),
     });
 
     const data: WorkerSearchResponse = await response.json();
@@ -181,8 +179,6 @@ export async function createTradeSearch(
     return {
       success: true,
       url: data.url,
-      searchId: data.id,
-      total: data.total,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -2,61 +2,174 @@
  * Cloudflare Worker: PoE Trade API Proxy
  *
  * Endpoints:
- *   POST /search - Create a trade search and return the search ID
+ *   POST /search - Create a trade search and return the search ID (cached via KV)
  *   GET  /leagues - Get available leagues
+ *
+ * Uses Cloudflare Workers KV to cache search results keyed by the regex string.
+ * This avoids hitting the PoE Trade API for identical queries.
  */
 
 interface Env {
   ALLOWED_ORIGIN: string;
+  TRADE_CACHE: KVNamespace;
 }
 
 interface TradeSearchRequest {
   league: string;
-  query: object;
+  query: TradeQuery;
+  regex?: string;
+}
+
+interface TradeQuery {
+  query: {
+    stats?: {
+      type: string;
+      filters: { id: string }[];
+      value?: { min: number };
+    }[];
+    filters?: {
+      map_filters?: {
+        filters?: {
+          map_iiq?: { min: number };
+          map_packsize?: { min: number };
+          map_iir?: { min: number };
+        };
+      };
+    };
+  };
 }
 
 interface TradeSearchResponse {
   id: string;
-  result: string[];
-  total: number;
+}
+
+interface CachedResult {
+  url: string;
 }
 
 const POE_TRADE_API = "https://www.pathofexile.com/api/trade";
+const CACHE_TTL_SECONDS = 7 * 24 * 60 * 60; // 1 week
 
-function corsHeaders(allowedOrigin: string): HeadersInit {
+function getAllowedOrigin(
+  requestOrigin: string,
+  allowedOrigin: string,
+): string {
+  if (requestOrigin.startsWith("http://localhost:")) return requestOrigin;
+  return allowedOrigin;
+}
+
+function corsHeaders(
+  requestOrigin: string,
+  allowedOrigin: string,
+): HeadersInit {
   return {
-    "Access-Control-Allow-Origin": allowedOrigin,
+    "Access-Control-Allow-Origin": getAllowedOrigin(
+      requestOrigin,
+      allowedOrigin,
+    ),
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Access-Control-Max-Age": "86400",
   };
 }
 
-function handleOptions(request: Request, env: Env): Response {
-  return new Response(null, {
-    status: 204,
-    headers: corsHeaders(env.ALLOWED_ORIGIN),
+function jsonResponse(
+  body: object,
+  status: number,
+  headers: HeadersInit,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...headers, "Content-Type": "application/json" },
   });
 }
 
-async function handleSearch(request: Request, env: Env): Promise<Response> {
-  const headers = corsHeaders(env.ALLOWED_ORIGIN);
+function handleOptions(origin: string, env: Env): Response {
+  return new Response(null, {
+    status: 204,
+    headers: corsHeaders(origin, env.ALLOWED_ORIGIN),
+  });
+}
+
+function logSearch(body: TradeSearchRequest, cacheHit: boolean): void {
+  const q = body.query?.query;
+  const stats = q?.stats ?? [];
+  const mapFilters = q?.filters?.map_filters?.filters;
+
+  const notGroup = stats.find((s) => s.type === "not");
+  const andGroup = stats.find((s) => s.type === "and");
+  const countGroup = stats.find((s) => s.type === "count");
+
+  const toIds = (group?: { filters: { id: string }[] }) =>
+    group?.filters.map((f) => f.id) ?? [];
+
+  console.log({
+    event: "search",
+    league: body.league,
+    cache: cacheHit ? "hit" : "miss",
+    regex: body.regex ?? null,
+    badModCount: notGroup?.filters.length ?? 0,
+    badModIds: toIds(notGroup),
+    goodModCount: (andGroup ?? countGroup)?.filters.length ?? 0,
+    goodModMode: andGroup ? "all" : countGroup ? "any" : null,
+    goodModIds: toIds(andGroup ?? countGroup),
+    iiq: mapFilters?.map_iiq?.min ?? null,
+    packsize: mapFilters?.map_packsize?.min ?? null,
+    iir: mapFilters?.map_iir?.min ?? null,
+  });
+}
+
+function toCacheKey(league: string, regex?: string): string | null {
+  return regex ? `${league}:${regex}` : null;
+}
+
+async function getCached(
+  env: Env,
+  cacheKey: string | null,
+): Promise<CachedResult | null> {
+  if (!cacheKey) return null;
+  return env.TRADE_CACHE.get<CachedResult>(cacheKey, "json");
+}
+
+async function putCache(
+  env: Env,
+  cacheKey: string | null,
+  result: CachedResult,
+): Promise<void> {
+  if (!cacheKey) return;
+  await env.TRADE_CACHE.put(cacheKey, JSON.stringify(result), {
+    expirationTtl: CACHE_TTL_SECONDS,
+  });
+}
+
+async function handleSearch(
+  request: Request,
+  origin: string,
+  env: Env,
+): Promise<Response> {
+  const headers = corsHeaders(origin, env.ALLOWED_ORIGIN);
 
   try {
     const body: TradeSearchRequest = await request.json();
 
     if (!body.league || !body.query) {
-      return new Response(
-        JSON.stringify({
-          error: "Missing 'league' or 'query' in request body",
-        }),
-        {
-          status: 400,
-          headers: { ...headers, "Content-Type": "application/json" },
-        },
+      return jsonResponse(
+        { error: "Missing 'league' or 'query' in request body" },
+        400,
+        headers,
       );
     }
 
+    const cacheKey = toCacheKey(body.league, body.regex);
+
+    const cached = await getCached(env, cacheKey);
+    if (cached) {
+      logSearch(body, true);
+      return jsonResponse({ ...cached, cached: true }, 200, headers);
+    }
+
+    logSearch(body, false);
+    // Query PoE Trade API
     const poeResponse = await fetch(
       `${POE_TRADE_API}/search/${encodeURIComponent(body.league)}`,
       {
@@ -88,42 +201,32 @@ async function handleSearch(request: Request, env: Env): Promise<Response> {
     }
 
     if (!poeResponse.ok) {
-      return new Response(
-        JSON.stringify({
+      return jsonResponse(
+        {
           error: `PoE API error: ${poeResponse.status}`,
           status: poeResponse.status,
-        }),
-        {
-          status: poeResponse.status,
-          headers: { ...headers, "Content-Type": "application/json" },
         },
+        poeResponse.status,
+        headers,
       );
     }
 
     const data: TradeSearchResponse = await poeResponse.json();
+    const result: CachedResult = {
+      url: `https://www.pathofexile.com/trade/search/${encodeURIComponent(body.league)}/${data.id}`,
+    };
 
-    return new Response(
-      JSON.stringify({
-        id: data.id,
-        total: data.total,
-        url: `https://www.pathofexile.com/trade/search/${encodeURIComponent(body.league)}/${data.id}`,
-      }),
-      {
-        status: 200,
-        headers: { ...headers, "Content-Type": "application/json" },
-      },
-    );
+    await putCache(env, cacheKey, result);
+
+    return jsonResponse(result, 200, headers);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: message }), {
-      status: 500,
-      headers: { ...headers, "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: message }, 500, headers);
   }
 }
 
-async function handleLeagues(request: Request, env: Env): Promise<Response> {
-  const headers = corsHeaders(env.ALLOWED_ORIGIN);
+async function handleLeagues(origin: string, env: Env): Promise<Response> {
+  const headers = corsHeaders(origin, env.ALLOWED_ORIGIN);
 
   try {
     const poeResponse = await fetch(`${POE_TRADE_API}/data/leagues`, {
@@ -133,26 +236,18 @@ async function handleLeagues(request: Request, env: Env): Promise<Response> {
     });
 
     if (!poeResponse.ok) {
-      return new Response(
-        JSON.stringify({ error: `PoE API error: ${poeResponse.status}` }),
-        {
-          status: poeResponse.status,
-          headers: { ...headers, "Content-Type": "application/json" },
-        },
+      return jsonResponse(
+        { error: `PoE API error: ${poeResponse.status}` },
+        poeResponse.status,
+        headers,
       );
     }
 
     const data = await poeResponse.json();
-    return new Response(JSON.stringify(data), {
-      status: 200,
-      headers: { ...headers, "Content-Type": "application/json" },
-    });
+    return jsonResponse(data as object, 200, headers);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    return new Response(JSON.stringify({ error: message }), {
-      status: 500,
-      headers: { ...headers, "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: message }, 500, headers);
   }
 }
 
@@ -161,29 +256,28 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname;
+    const origin = request.headers.get("Origin") || "";
 
     if (request.method === "OPTIONS") {
-      return handleOptions(request, env);
+      return handleOptions(origin, env);
     }
 
     if (path === "/search" && request.method === "POST") {
-      return handleSearch(request, env);
+      return handleSearch(request, origin, env);
     }
 
     if (path === "/leagues" && request.method === "GET") {
-      return handleLeagues(request, env);
+      return handleLeagues(origin, env);
     }
 
     if (path === "/" || path === "/health") {
-      return new Response(
-        JSON.stringify({ status: "ok", service: "poe-trade-proxy" }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
+      return jsonResponse(
+        { status: "ok", service: "poe-trade-proxy" },
+        200,
+        {},
       );
     }
 
-    return new Response(JSON.stringify({ error: "Not found" }), {
-      status: 404,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ error: "Not found" }, 404, {});
   },
 };

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,6 +1,26 @@
 # Cloudflare Worker configuration for PoE Trade API Proxy
 name = "poe-trade-proxy"
 main = "src/index.ts"
+compatibility_date = "2026-04-14"
 
 [vars]
 ALLOWED_ORIGIN = "https://poe.re"
+
+[[kv_namespaces]]
+binding = "TRADE_CACHE"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+[observability]
+enabled = false
+head_sampling_rate = 1
+
+[observability.logs]
+enabled = true
+head_sampling_rate = 1
+persist = true
+invocation_logs = true
+
+[observability.traces]
+enabled = false
+persist = true
+head_sampling_rate = 1


### PR DESCRIPTION
**Problem**: The PoE Trade API rate-limits by IP, and our Cloudflare Worker shares egress IPs, too many users hitting the trade button causes 429s.

**Solution**: Use Cloudflare Workers KV as a cache layer. The website's generated regex string acts as a natural cache key, users with the same map mod configuration produce the same regex, so they can share a single PoE API result.
This is a bit optimistic as the quality/quantity/rarity integer filters are also taken into account, we can see how this affects the rate limit, **if deemed insufficient, we can remove the quantity and rarity filters from the trade search to increase overlap on user applied search/configuration.**

  Flow:
  Client sends { league, query, regex }
          │
    Key = "league:regex"
          │
     KV lookup ──── hit ──→ return cached result (no PoE API call)
          │
        miss
          │
     Query PoE API → store result in KV (1 week TTL) → return result

  Changes:
  - TradeUrlBuilder.ts: Sends the regex string alongside the trade query to the worker
  - OptimizedMapMods.tsx: Passes the current result (regex) into TradeSettings
  - worker/src/index.ts: Added toCacheKey, getCached, putCache functions + cache hit/miss logging
  - worker/wrangler.toml: Added TRADE_CACHE KV namespace binding

  Setup required: Create the KV namespace via `npx wrangler kv namespace create TRADE_CACHE` and put the returned ID in `wrangler.toml`.
  
  
  PS; Added back the CORS config for localhost testing, as it would not have increase vulnerability to malicious usage compared to directly going to poe.re