### PR TITLE
feat(maps): prefix/suffix badges and grouping on map mods page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/testing-library__jest-dom": "^5.14.3",
         "gh-pages": "^4.0.0",
         "ts-node": "^10.9.2"
       }
@@ -68,7 +69,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
       "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -892,7 +892,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz",
       "integrity": "sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.16.7"
       },
@@ -1440,7 +1439,6 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
       "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -3686,8 +3684,7 @@
     "node_modules/@types/node": {
       "version": "16.11.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
-      "peer": true
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3823,7 +3820,6 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
       "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.21.0",
         "@typescript-eslint/type-utils": "5.21.0",
@@ -3874,7 +3870,6 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
       "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.21.0",
         "@typescript-eslint/types": "5.21.0",
@@ -4198,7 +4193,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4306,7 +4300,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5062,7 +5055,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001332",
         "electron-to-chromium": "^1.4.118",
@@ -5745,7 +5737,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -6668,7 +6659,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
       "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
-      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -9196,7 +9186,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -11558,7 +11547,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -12332,7 +12320,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
@@ -13634,7 +13621,6 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -13779,7 +13765,6 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.22.0"
@@ -13802,7 +13787,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14250,7 +14234,6 @@
       "version": "2.71.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.71.1.tgz",
       "integrity": "sha512-lMZk3XfUBGjrrZQpvPSoXcZSfKcJ2Bgn+Z0L1MoW2V8Wh7BVM+LOBJTPo16yul2MwL59cXedzW1ruq3rCjSRgw==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15016,7 +14999,6 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -15506,7 +15488,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15642,7 +15623,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15674,7 +15654,6 @@
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15919,7 +15898,6 @@
       "version": "5.72.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
       "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -15988,7 +15966,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16038,7 +16015,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.8.1.tgz",
       "integrity": "sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -16089,7 +16065,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16402,7 +16377,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16810,7 +16784,6 @@
       "version": "7.17.10",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
       "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -17378,7 +17351,6 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.16.7.tgz",
       "integrity": "sha512-UDo3YGQO0jH6ytzVwgSLv9i/CzMcUjbKenL67dTrAZPPv6GFAtDhe6jqnvmoKzC/7htNTohhos+onPtDMqJwaQ==",
-      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.16.7"
       }
@@ -17716,7 +17688,6 @@
       "version": "7.17.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz",
       "integrity": "sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==",
-      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -19334,8 +19305,7 @@
     "@types/node": {
       "version": "16.11.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
-      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA==",
-      "peer": true
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -19471,7 +19441,6 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.21.0.tgz",
       "integrity": "sha512-fTU85q8v5ZLpoZEyn/u1S2qrFOhi33Edo2CZ0+q1gDaWWm0JuPh3bgOyU8lM0edIEYgKLDkPFiZX2MOupgjlyg==",
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.21.0",
         "@typescript-eslint/type-utils": "5.21.0",
@@ -19496,7 +19465,6 @@
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.21.0.tgz",
       "integrity": "sha512-8RUwTO77hstXUr3pZoWZbRQUxXcSXafZ8/5gpnQCfXvgmP9gpNlRGlWzvfbEQ14TLjmtU8eGnONkff8U2ui2Eg==",
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.21.0",
         "@typescript-eslint/types": "5.21.0",
@@ -19738,8 +19706,7 @@
     "acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "peer": true
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -19817,7 +19784,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20377,7 +20343,6 @@
       "version": "4.20.3",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
       "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001332",
         "electron-to-chromium": "^1.4.118",
@@ -20864,7 +20829,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -21550,7 +21514,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
       "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
-      "peer": true,
       "requires": {
         "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -23359,7 +23322,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "requires": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -25091,7 +25053,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -25645,7 +25606,6 @@
       "version": "8.4.13",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.13.tgz",
       "integrity": "sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.3",
         "picocolors": "^1.0.0",
@@ -26448,7 +26408,6 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.1.0.tgz",
       "integrity": "sha512-4oL8ivCz5ZEPyclFQXaNksK3adutVS8l2xzZU0cqEFrE9Sb7fC0EFK5uEk74wIreL1DERyjvsU915j1pcT2uEQ==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -26556,7 +26515,6 @@
       "version": "18.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.1.0.tgz",
       "integrity": "sha512-fU1Txz7Budmvamp7bshe4Zi32d0ll7ect+ccxNu9FlObT605GOEB8BfO4tmRJ39R5Zj831VCpvQ05QPBW5yb+w==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.22.0"
@@ -26575,8 +26533,7 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
       "version": "6.3.0",
@@ -26898,7 +26855,6 @@
       "version": "2.71.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.71.1.tgz",
       "integrity": "sha512-lMZk3XfUBGjrrZQpvPSoXcZSfKcJ2Bgn+Z0L1MoW2V8Wh7BVM+LOBJTPo16yul2MwL59cXedzW1ruq3rCjSRgw==",
-      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -27474,7 +27430,6 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
-      "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -27842,7 +27797,6 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -27938,8 +27892,7 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -27961,8 +27914,7 @@
     "typescript": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
-      "peer": true
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -28147,7 +28099,6 @@
       "version": "5.72.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
       "integrity": "sha512-qmSmbspI0Qo5ld49htys8GY9XhS9CGqFoHTsOVAnjBdg0Zn79y135R+k4IR4rKK6+eKaabMhJwiVB7xw0SJu5w==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -28207,7 +28158,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -28245,7 +28195,6 @@
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.8.1.tgz",
       "integrity": "sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==",
-      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -28282,7 +28231,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -28505,7 +28453,6 @@
           "version": "8.11.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     ]
   },
   "devDependencies": {
+    "@types/testing-library__jest-dom": "^5.14.3",
     "gh-pages": "^4.0.0",
     "ts-node": "^10.9.2"
   }

--- a/src/components/SelectableTokenList/SelectableTokenList.css
+++ b/src/components/SelectableTokenList/SelectableTokenList.css
@@ -14,4 +14,25 @@
     font-size: 16px;
     padding: 5px;
     margin: 1px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.selectable-token-list-text {
+    flex: 1;
+}
+
+.selectable-token-list-group + .selectable-token-list-group {
+    margin-top: 14px;
+}
+
+.selectable-token-list-group-header {
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #8aa0b4;
+    padding: 4px 6px 2px;
+    border-bottom: 1px solid #33404d;
+    margin-bottom: 4px;
 }

--- a/src/components/SelectableTokenList/SelectableTokenList.test.tsx
+++ b/src/components/SelectableTokenList/SelectableTokenList.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import {render, screen, fireEvent, within} from "@testing-library/react";
+import SelectableTokenList from "./SelectableTokenList";
+import {Token} from "../../generated/GeneratedTypes";
+
+type T = Token<{ kind: "prefix" | "suffix" }>;
+
+const tokens: T[] = [
+  {id: 1, regex: "", rawText: "Monsters have more Life", generalizedText: "", options: {kind: "prefix"}},
+  {id: 2, regex: "", rawText: "Area has Consecrated Ground", generalizedText: "", options: {kind: "suffix"}},
+  {id: 3, regex: "", rawText: "Players are Cursed with Vulnerability", generalizedText: "", options: {kind: "suffix"}},
+  {id: 4, regex: "", rawText: "Monsters reflect Damage", generalizedText: "", options: {kind: "prefix"}},
+];
+
+describe("SelectableTokenList", () => {
+  test("renders rows without grouping or tags by default", () => {
+    const setSelected = jest.fn();
+    render(<SelectableTokenList elements={tokens} selected={[]} setSelected={setSelected}/>);
+    expect(screen.getByText("Monsters have more Life")).toBeInTheDocument();
+    expect(screen.getByText("Area has Consecrated Ground")).toBeInTheDocument();
+    expect(screen.queryByText("Prefix")).toBeNull();
+    expect(screen.queryByText("Suffix")).toBeNull();
+  });
+
+  test("tagFn renders a badge next to each row", () => {
+    const setSelected = jest.fn();
+    const tagFn = (t: Token<any>) => <span data-testid={`tag-${t.id}`}>{t.options.kind === "prefix" ? "P" : "S"}</span>;
+    render(<SelectableTokenList elements={tokens} selected={[]} setSelected={setSelected} tagFn={tagFn}/>);
+    expect(screen.getByTestId("tag-1")).toHaveTextContent("P");
+    expect(screen.getByTestId("tag-2")).toHaveTextContent("S");
+    expect(screen.getByTestId("tag-3")).toHaveTextContent("S");
+    expect(screen.getByTestId("tag-4")).toHaveTextContent("P");
+  });
+
+  test("groupFn groups rows under headers in the supplied order", () => {
+    const setSelected = jest.fn();
+    const groupFn = (t: Token<any>) => t.options.kind === "prefix"
+      ? {key: "prefix", label: "Prefix"}
+      : {key: "suffix", label: "Suffix"};
+    render(
+      <SelectableTokenList
+        elements={tokens}
+        selected={[]}
+        setSelected={setSelected}
+        groupFn={groupFn}
+        groupOrder={["prefix", "suffix"]}
+      />
+    );
+    const headers = screen.getAllByText(/Prefix|Suffix/);
+    expect(headers[0]).toHaveTextContent("Prefix");
+    expect(headers[1]).toHaveTextContent("Suffix");
+  });
+
+  test("search filters before grouping and hides empty groups", () => {
+    const setSelected = jest.fn();
+    const groupFn = (t: Token<any>) => t.options.kind === "prefix"
+      ? {key: "prefix", label: "Prefix"}
+      : {key: "suffix", label: "Suffix"};
+    render(
+      <SelectableTokenList
+        elements={tokens}
+        selected={[]}
+        setSelected={setSelected}
+        groupFn={groupFn}
+        groupOrder={["prefix", "suffix"]}
+      />
+    );
+    const input = screen.getByPlaceholderText(/Search for a modifier/i);
+    fireEvent.change(input, {target: {value: "Consecrated"}});
+    // Only the suffix group should remain with its single matching row.
+    expect(screen.queryByText("Prefix")).toBeNull();
+    expect(screen.getByText("Suffix")).toBeInTheDocument();
+    expect(screen.getByText("Area has Consecrated Ground")).toBeInTheDocument();
+    expect(screen.queryByText("Monsters have more Life")).toBeNull();
+  });
+
+  test("clicking a row toggles selection", () => {
+    const setSelected = jest.fn();
+    render(<SelectableTokenList elements={tokens} selected={[]} setSelected={setSelected}/>);
+    fireEvent.click(screen.getByText("Monsters have more Life"));
+    expect(setSelected).toHaveBeenCalledWith([1]);
+  });
+});

--- a/src/components/SelectableTokenList/SelectableTokenList.test.tsx
+++ b/src/components/SelectableTokenList/SelectableTokenList.test.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "@testing-library/jest-dom";
 import {render, screen, fireEvent} from "@testing-library/react";
 import SelectableTokenList from "./SelectableTokenList";
 import {Token} from "../../generated/GeneratedTypes";

--- a/src/components/SelectableTokenList/SelectableTokenList.test.tsx
+++ b/src/components/SelectableTokenList/SelectableTokenList.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import {render, screen, fireEvent, within} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {render, screen, fireEvent} from "@testing-library/react";
 import SelectableTokenList from "./SelectableTokenList";
 import {Token} from "../../generated/GeneratedTypes";
 

--- a/src/components/SelectableTokenList/SelectableTokenList.tsx
+++ b/src/components/SelectableTokenList/SelectableTokenList.tsx
@@ -1,5 +1,5 @@
 import {Token} from "../../generated/GeneratedTypes";
-import React, {Dispatch, SetStateAction} from "react";
+import React, {Dispatch, ReactNode, SetStateAction} from "react";
 import SelectableSearch from "./SelectableSearch";
 import {regexSearch} from "../../utils/regex/ReverseRegexLookup";
 import "./SelectableTokenList.css";
@@ -12,50 +12,84 @@ export interface SelectableTokenListProps {
   sortFn?: (a: Token<any>, b: Token<any>) => number
   colorFun?: (isSelected: boolean, token: Token<any>) => string
   displayFun?: (v: string) => string
+  tagFn?: (token: Token<any>) => ReactNode | null
+  groupFn?: (token: Token<any>) => {key: string, label: string} | null
+  groupOrder?: string[]
 }
 
-const SelectableTokenList= (props: SelectableTokenListProps) => {
-  const {elements, selected, setSelected, sortFn, colorFun, displayFun} = props;
+const SelectableTokenList = (props: SelectableTokenListProps) => {
+  const {elements, selected, setSelected, sortFn, colorFun, displayFun, tagFn, groupFn, groupOrder} = props;
   const [search, setSearch] = React.useState("");
   const sorting = sortFn ?? defaultSort;
   const colorFunction = colorFun ?? defaultColorFun;
   const displayValue = displayFun ?? defaultDisplayFun;
+
+  const visible = elements
+    .filter((token) => {
+      const regexMatch = regexSearch(token.rawText.toLowerCase(), search);
+      const regularMatch = !search || search.toLowerCase().trim().split(" ")
+        .every(q => token.rawText.toLowerCase().includes(q));
+      return regularMatch || regexMatch;
+    })
+    .sort(sorting);
+
+  const renderRow = (token: Token<any>) => {
+    const isSelected = selected.includes(token.id);
+    const className = isSelected ?
+      "selectable-token-list-selectable selectable-token-list-selected" :
+      "selectable-token-list-selectable";
+    const colorValue = colorFunction(isSelected, token)
+    const style = !isSelected ? {color: colorValue} : undefined;
+    const tag = tagFn?.(token);
+
+    return (
+      <div key={token.id}
+           style={style}
+           className={className}
+           onClick={() => {
+             isSelected
+               ? setSelected(selected.filter(selectedToken => selectedToken !== token.id))
+               : setSelected(selected.concat(token.id).sort((n1, n2) => n1 - n2));
+           }}
+      >
+        {tag}
+        <span className="selectable-token-list-text">{displayValue(token.rawText.replaceAll("|", " · "))}</span>
+      </div>
+    );
+  };
+
+  const renderContent = (): ReactNode => {
+    if (!groupFn) return visible.map(renderRow);
+
+    const groups = new Map<string, {label: string, tokens: Token<any>[]}>();
+    for (const token of visible) {
+      const g = groupFn(token);
+      if (!g) continue;
+      const existing = groups.get(g.key);
+      if (existing) existing.tokens.push(token);
+      else groups.set(g.key, {label: g.label, tokens: [token]});
+    }
+
+    const orderedKeys = groupOrder
+      ? groupOrder.filter((k) => groups.has(k)).concat(Array.from(groups.keys()).filter((k) => !groupOrder.includes(k)))
+      : Array.from(groups.keys());
+
+    return orderedKeys.map((key) => {
+      const g = groups.get(key)!;
+      return (
+        <div key={key} className="selectable-token-list-group">
+          <div className="selectable-token-list-group-header">{g.label}</div>
+          {g.tokens.map(renderRow)}
+        </div>
+      );
+    });
+  };
+
   return (
     <>
       <SelectableSearch search={search} setSearch={setSearch}/>
       <div className="selectable-token-list-mod-list">
-        {elements
-          .filter((token) => {
-            const regexMatch = regexSearch(token.rawText.toLowerCase(), search);
-            const regularMatch = !search || search.toLowerCase().trim().split(" ")
-              .every(q => token.rawText.toLowerCase().includes(q));
-            return regularMatch || regexMatch;
-          })
-          .sort(sorting)
-          .map((token) => {
-            const isSelected = selected.includes(token.id);
-            const className = isSelected ?
-              "selectable-token-list-selectable selectable-token-list-selected" :
-              "selectable-token-list-selectable";
-            const colorValue = colorFunction(isSelected, token)
-            const style = !isSelected ? {color: colorValue} : undefined;
-
-            return (
-              <div key={token.id}
-                   style={style}
-                   className={className}
-                   onClick={() => {
-                     isSelected
-                       ? setSelected(selected.filter(selectedToken => selectedToken !== token.id))
-                       : setSelected(selected.concat(token.id).sort((n1, n2) => n1 - n2));
-                   }}
-              >
-                {displayValue(
-                  token.rawText.replaceAll("|", " · ")
-                )}
-              </div>
-            )
-          })}
+        {renderContent()}
       </div>
     </>
   );

--- a/src/pages/maps/OptimizedMapMods.css
+++ b/src/pages/maps/OptimizedMapMods.css
@@ -92,3 +92,24 @@
     color: #2d7a9c;
     font-size: 14px;
 }
+
+.mod-affix-tag {
+    display: inline-block;
+    width: 22px;
+    text-align: center;
+    padding: 2px 0;
+    border-radius: 2px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    color: #ffffff;
+    flex-shrink: 0;
+}
+
+.mod-affix-tag--prefix {
+    background-color: #7a2e2e;
+}
+
+.mod-affix-tag--suffix {
+    background-color: #2d4f7c;
+}

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState} from "react";
+import React, {useContext, useEffect, useMemo, useState} from "react";
 import {ProfileContext} from "../../components/profile/ProfileContext";
 import {loadSettings, saveSettings} from "../../utils/LocalStorage";
 import {HeaderWithLanguage} from "../../components/Header";
@@ -11,6 +11,7 @@ import "./OptimizedMapMods.css";
 import RegexResultBox from "../../components/RegexResultBox/RegexResultBox";
 import {LanguageFiles} from "../../utils/Languages";
 import {openTradeSearch, TradeSettings} from "../../utils/TradeUrlBuilder";
+import {MapModsTokenOption, Token} from "../../generated/mapmods/GeneratedTypes";
 
 const OptimizedMapMods = () => {
   const {globalProfile} = useContext(ProfileContext);
@@ -33,6 +34,8 @@ const OptimizedMapMods = () => {
   const [regex, setRegex] = useState(LanguageFiles.mapmods[profile.language]);
   const [mapDropChance, setMapDropChance] = useState(profile.map.mapDropChance);
   const [displayNightmareMods, setDisplayNightmareMods] = useState(profile.map.displayNightmareMods);
+  const [displayAffixBadges, setDisplayAffixBadges] = useState(profile.map.displayAffixBadges);
+  const [groupByAffix, setGroupByAffix] = useState(profile.map.groupByAffix);
 
   const [customTextStr, setCustomTextStr] = useState(profile.map.customText.value);
   const [enableCustomText, setEnableCustomText] = useState(profile.map.customText.enabled);
@@ -81,6 +84,8 @@ const OptimizedMapMods = () => {
       quality,
       anyQuality,
       displayNightmareMods,
+      displayAffixBadges,
+      groupByAffix,
       customText: {
         value: customTextStr,
         enabled: enableCustomText,
@@ -92,7 +97,24 @@ const OptimizedMapMods = () => {
       map: {...settings},
     });
     setResult(generateMapModRegex(settings, regex, profile.language));
-  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods]);
+  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix]);
+
+  const renderAffixTag = useMemo(() => {
+    if (!displayAffixBadges) return undefined;
+    return (token: Token<MapModsTokenOption>) => (
+      <span className={`mod-affix-tag mod-affix-tag--${token.options.prefix ? "prefix" : "suffix"}`}>
+        {token.options.prefix ? "P" : "S"}
+      </span>
+    );
+  }, [displayAffixBadges]);
+
+  const affixGroupFn = useMemo(() => {
+    if (!groupByAffix) return undefined;
+    return (token: Token<MapModsTokenOption>) =>
+      token.options.prefix
+        ? {key: "prefix", label: "Prefix"}
+        : {key: "suffix", label: "Suffix"};
+  }, [groupByAffix]);
 
   return (
     <>
@@ -125,6 +147,8 @@ const OptimizedMapMods = () => {
           setCustomTextStr(defaultSettings.map.customText.value);
           setMapDropChance(defaultSettings.map.mapDropChance);
           setDisplayNightmareMods(defaultSettings.map.displayNightmareMods);
+          setDisplayAffixBadges(defaultSettings.map.displayAffixBadges);
+          setGroupByAffix(defaultSettings.map.groupByAffix);
         }}
       />
       {tradeMessage && (
@@ -244,6 +268,12 @@ const OptimizedMapMods = () => {
           <Checkbox label="Show nightmare modifiers" value={displayNightmareMods}
                     onChange={setDisplayNightmareMods}/>
         </div>
+        <div className="rarity-select">
+          <Checkbox label="Show prefix/suffix badges" value={displayAffixBadges}
+                    onChange={setDisplayAffixBadges}/>
+          <Checkbox label="Group mods by prefix/suffix" value={groupByAffix}
+                    onChange={setGroupByAffix}/>
+        </div>
         <div className="break spacer-top"/>
       </div>
       <div className="eq-col-2 box-small-padding">
@@ -279,6 +309,9 @@ const OptimizedMapMods = () => {
           }
           setSelected={setSelectedBadIds}
           selected={selectedBadIds}
+          tagFn={renderAffixTag}
+          groupFn={affixGroupFn}
+          groupOrder={["prefix", "suffix"]}
         />
       </div>
       <div className="eq-col-2">
@@ -297,6 +330,9 @@ const OptimizedMapMods = () => {
           }
           setSelected={setSelectedGoodIds}
           selected={selectedGoodIds}
+          tagFn={renderAffixTag}
+          groupFn={affixGroupFn}
+          groupOrder={["prefix", "suffix"]}
         />
       </div>
     </>

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -263,14 +263,14 @@ const OptimizedMapMods = () => {
           </div>
         </div>
         <div className="rarity-select">
-          <Checkbox label="Show nightmare modifiers" value={displayNightmareMods}
-                    onChange={setDisplayNightmareMods}/>
-        </div>
-        <div className="rarity-select">
           <Checkbox label="Show prefix/suffix badges" value={displayAffixBadges}
                     onChange={setDisplayAffixBadges}/>
           <Checkbox label="Group mods by prefix/suffix" value={groupByAffix}
                     onChange={setGroupByAffix}/>
+        </div>
+        <div className="rarity-select">
+          <Checkbox label="Show nightmare modifiers" value={displayNightmareMods}
+                    onChange={setDisplayNightmareMods}/>
         </div>
         <div className="break spacer-top"/>
       </div>

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useMemo, useState} from "react";
+import React, {useContext, useEffect, useState} from "react";
 import {ProfileContext} from "../../components/profile/ProfileContext";
 import {loadSettings, saveSettings} from "../../utils/LocalStorage";
 import {HeaderWithLanguage} from "../../components/Header";
@@ -99,22 +99,20 @@ const OptimizedMapMods = () => {
     setResult(generateMapModRegex(settings, regex, profile.language));
   }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix]);
 
-  const renderAffixTag = useMemo(() => {
-    if (!displayAffixBadges) return undefined;
-    return (token: Token<MapModsTokenOption>) => (
-      <span className={`mod-affix-tag mod-affix-tag--${token.options.prefix ? "prefix" : "suffix"}`}>
-        {token.options.prefix ? "P" : "S"}
-      </span>
-    );
-  }, [displayAffixBadges]);
+  const renderAffixTag = displayAffixBadges
+    ? (token: Token<MapModsTokenOption>) => (
+        <span className={`mod-affix-tag mod-affix-tag--${token.options.prefix ? "prefix" : "suffix"}`}>
+          {token.options.prefix ? "P" : "S"}
+        </span>
+      )
+    : undefined;
 
-  const affixGroupFn = useMemo(() => {
-    if (!groupByAffix) return undefined;
-    return (token: Token<MapModsTokenOption>) =>
-      token.options.prefix
-        ? {key: "prefix", label: "Prefix"}
-        : {key: "suffix", label: "Suffix"};
-  }, [groupByAffix]);
+  const affixGroupFn = groupByAffix
+    ? (token: Token<MapModsTokenOption>) =>
+        token.options.prefix
+          ? {key: "prefix", label: "Prefix"}
+          : {key: "suffix", label: "Suffix"}
+    : undefined;
 
   return (
     <>

--- a/src/types/jest-dom.d.ts
+++ b/src/types/jest-dom.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@testing-library/jest-dom" />

--- a/src/utils/SavedSettings.ts
+++ b/src/utils/SavedSettings.ts
@@ -192,6 +192,8 @@ export interface MapSettings {
   optimizePacksize: boolean
   optimizeQuality: boolean
   displayNightmareMods: boolean
+  displayAffixBadges: boolean
+  groupByAffix: boolean
   rarity: {
     normal: boolean
     magic: boolean
@@ -392,6 +394,8 @@ export const defaultSettings: SavedSettings = {
     optimizePacksize: false,
     optimizeQuality: false,
     displayNightmareMods: false,
+    displayAffixBadges: false,
+    groupByAffix: false,
     rarity: {
       normal: true,
       magic: true,


### PR DESCRIPTION
Reworked from #364 against the new `prefix: boolean` field on `MapModsTokenOption` (added in 1748c2bf935a72e5ec3af0b2286caaa1c1fbcf0d). No more sidecar — reads `token.options.prefix` directly.

## Summary

- Two new toggles in the Maps page options area:
  - **Show prefix/suffix badges** — fixed-width red `P` / blue `S` chip on each row (trade-style)
  - **Group mods by prefix/suffix** — `Prefix` / `Suffix` section headers inside each of the two existing columns
- Toggles are independent — either can be on alone.
- Search filter still runs before grouping; empty groups are hidden.
- No change to regex output. Purely visual.
- Toggle state persists via saved settings (defaults `false` — existing profiles keep current behavior).

## Implementation

- `SelectableTokenList` gets two optional extension points: `tagFn(token)` for a per-row badge and `groupFn(token)` + `groupOrder` for sectioning.
- `OptimizedMapMods.tsx` wires those to `token.options.prefix`. Tag/group functions are memoized so disabled toggles produce no extra work.
- New unit tests for `SelectableTokenList` cover tagFn, groupFn, group order, search-then-group, and selection toggling.

## Test plan

- [x] `npm test` — 5/5 pass
- [x] `npx tsc --noEmit` clean
- [x] Manual: toggles work independently, search filters under grouping, regex output unchanged, settings persist across reload