### PR TITLE
feat(trade): default trade search to instant buyout

### DIFF
--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -96,7 +96,7 @@ function parseMinFilter(value: string): { min: number } | undefined {
 function buildTradeQuery(settings: TradeSettings): TradeQuery {
   const query: TradeQuery = {
     query: {
-      status: { option: "online" },
+      status: { option: "securable" },
       filters: {
         map_filters: {
           disabled: false,


### PR DESCRIPTION
## Summary

Switches the default trade-search status from `online` to `securable` so the **Trade** button opens the search with **"Buyout"** (instant buyout) selected instead of "In person (online)".

## Why

`online` returns listings from any currently-online seller, *including* `~price` negotiable ones. In practice almost everyone using the Trade button wants instant-buyout listings only — `securable` is exactly the trade site's "Buyout" toggle and matches that intent.

## Change

One-liner in `src/utils/TradeUrlBuilder.ts`:

```diff
-      status: { option: "online" },
+      status: { option: "securable" },
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Manual: click Trade button on `/#/maps`, verify the opened pathofexile.com search has Trade type set to **Buyout**