### PR TITLE
feat(trade): 8-mod map filter and corrupted include/exclude wiring

### DIFF
--- a/src/components/TradeAsterisk.css
+++ b/src/components/TradeAsterisk.css
@@ -1,0 +1,5 @@
+.trade-asterisk {
+    color: #2d7a9c;
+    font-weight: bold;
+    margin-left: 2px;
+}

--- a/src/components/TradeAsterisk.tsx
+++ b/src/components/TradeAsterisk.tsx
@@ -1,0 +1,4 @@
+import React from "react";
+import "./TradeAsterisk.css";
+
+export const TradeAsterisk = () => <span className="trade-asterisk">*</span>;

--- a/src/pages/maps/OptimizedMapMods.css
+++ b/src/pages/maps/OptimizedMapMods.css
@@ -78,12 +78,6 @@
     animation: fadeIn 0.3s ease-in;
 }
 
-.trade-compatible {
-    color: #2d7a9c;
-    font-weight: bold;
-    margin-left: 2px;
-}
-
 .trade-info-text {
     padding: 0;
     margin-left: 14px;

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -36,6 +36,8 @@ const OptimizedMapMods = () => {
   const [displayNightmareMods, setDisplayNightmareMods] = useState(profile.map.displayNightmareMods);
   const [displayAffixBadges, setDisplayAffixBadges] = useState(profile.map.displayAffixBadges);
   const [groupByAffix, setGroupByAffix] = useState(profile.map.groupByAffix);
+  const [tradeEightModOnly, setTradeEightModOnly] = useState(profile.map.tradeEightModOnly);
+  const eightModDisabled = corrupted.enabled && !corrupted.include;
 
   const [customTextStr, setCustomTextStr] = useState(profile.map.customText.value);
   const [enableCustomText, setEnableCustomText] = useState(profile.map.customText.enabled);
@@ -54,6 +56,8 @@ const OptimizedMapMods = () => {
         packsize,
         itemRarity,
         regex: result,
+        eightModOnly: tradeEightModOnly && !eightModDisabled,
+        corrupted,
       };
       const tradeResult = await openTradeSearch(settings);
       if (tradeResult.success) {
@@ -86,6 +90,7 @@ const OptimizedMapMods = () => {
       displayNightmareMods,
       displayAffixBadges,
       groupByAffix,
+      tradeEightModOnly,
       customText: {
         value: customTextStr,
         enabled: enableCustomText,
@@ -97,7 +102,7 @@ const OptimizedMapMods = () => {
       map: {...settings},
     });
     setResult(generateMapModRegex(settings, regex, profile.language));
-  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix]);
+  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix, tradeEightModOnly]);
 
   const renderAffixTag = displayAffixBadges
     ? (token: Token<MapModsTokenOption>) => (
@@ -147,6 +152,7 @@ const OptimizedMapMods = () => {
           setDisplayNightmareMods(defaultSettings.map.displayNightmareMods);
           setDisplayAffixBadges(defaultSettings.map.displayAffixBadges);
           setGroupByAffix(defaultSettings.map.groupByAffix);
+          setTradeEightModOnly(defaultSettings.map.tradeEightModOnly);
         }}
       />
       {tradeMessage && (
@@ -233,6 +239,11 @@ const OptimizedMapMods = () => {
                    onChange={v => setRarity({...rarity, include: false})}/>
             <label htmlFor="maps-exclude" className="radio-button-map">Exclude</label>
           </div>
+        </div>
+        <div className="rarity-select">
+          <Checkbox label="Search for 8-mod maps only (Trade)" value={tradeEightModOnly}
+                    onChange={setTradeEightModOnly}
+                    disabled={eightModDisabled}/>
         </div>
         <div className="rarity-select">
           <Checkbox label="Corrupted Map" value={corrupted.enabled}

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -9,6 +9,7 @@ import {Checkbox} from "../vendor/Vendor";
 import {generateMapModRegex} from "./OptimizedMapOutput";
 import "./OptimizedMapMods.css";
 import RegexResultBox from "../../components/RegexResultBox/RegexResultBox";
+import {TradeAsterisk} from "../../components/TradeAsterisk";
 import {LanguageFiles} from "../../utils/Languages";
 import {openTradeSearch, TradeSettings} from "../../utils/TradeUrlBuilder";
 import {MapModsTokenOption, Token} from "../../generated/mapmods/GeneratedTypes";
@@ -165,11 +166,11 @@ const OptimizedMapMods = () => {
         languages. <br/> English now has nightmare mods, will keep updating.</p>
       <p className="trade-info-text">* Fields marked with an asterisk are compatible with the Trade search.</p>
       <div className="full-size generic-top-element">
-        <label className="modifier-search-label" htmlFor="quantity">Quantity of at least<span className="trade-compatible">*</span></label>
+        <label className="modifier-search-label" htmlFor="quantity">Quantity of at least<TradeAsterisk/></label>
         <input type="search" className="modifier-quantity-box" id="quantity" name="search-mod" value={quantity}
                onChange={v => setQuantity(v.target.value)}/>
 
-        <label className="modifier-search-label" htmlFor="pack-size">Pack Size of at least<span className="trade-compatible">*</span></label>
+        <label className="modifier-search-label" htmlFor="pack-size">Pack Size of at least<TradeAsterisk/></label>
         <input type="search" className="modifier-quantity-box" id="pack-size" name="search-mod" value={packsize}
                onChange={v => setPacksize(v.target.value)}/>
 
@@ -177,7 +178,7 @@ const OptimizedMapMods = () => {
         <input type="search" className="modifier-quantity-box" id="mapdrop" name="search-mod" value={mapDropChance}
                onChange={v => setMapDropChance(v.target.value)}/>
 
-        <label className="modifier-search-label" htmlFor="itemRarity">Item rarity of at least<span className="trade-compatible">*</span></label>
+        <label className="modifier-search-label" htmlFor="itemRarity">Item rarity of at least<TradeAsterisk/></label>
         <input type="search" className="modifier-quantity-box" id="itemRarity" name="search-mod" value={itemRarity}
                onChange={v => setItemRarity(v.target.value)}/>
         <div className="break"/>
@@ -241,12 +242,12 @@ const OptimizedMapMods = () => {
           </div>
         </div>
         <div className="rarity-select">
-          <Checkbox label="Search for 8-mod maps only (Trade)" value={tradeEightModOnly}
+          <Checkbox label={<>Only 8-mod maps (trade webpage query only)<TradeAsterisk/></>} value={tradeEightModOnly}
                     onChange={setTradeEightModOnly}
                     disabled={eightModDisabled}/>
         </div>
         <div className="rarity-select">
-          <Checkbox label="Corrupted Map" value={corrupted.enabled}
+          <Checkbox label={<>Corrupted Map<TradeAsterisk/></>} value={corrupted.enabled}
                     onChange={(e) => setCorrupted({...corrupted, enabled: !corrupted.enabled})}/>
           <div className="radio-button-corrupted">
             <input type="radio" className="radio-button-map" id="corrupted-include" name="corrupted-include"

--- a/src/pages/vendor/Vendor.tsx
+++ b/src/pages/vendor/Vendor.tsx
@@ -1,4 +1,4 @@
-import React, {Dispatch, SetStateAction, useContext, useEffect} from 'react';
+import React, {Dispatch, ReactNode, SetStateAction, useContext, useEffect} from 'react';
 import './Vendor.css';
 import socketRed from '../../img/red-socket.png';
 import socketGreen from '../../img/green-socket.png';
@@ -308,7 +308,7 @@ const Vendor = () => {
 
 
 interface CheckboxProps {
-  label: string
+  label: ReactNode
   value: boolean
   onChange: Dispatch<SetStateAction<boolean>>
   className?: string

--- a/src/pages/vendor/Vendor.tsx
+++ b/src/pages/vendor/Vendor.tsx
@@ -312,6 +312,7 @@ interface CheckboxProps {
   value: boolean
   onChange: Dispatch<SetStateAction<boolean>>
   className?: string
+  disabled?: boolean
 }
 
 interface LinkCheckboxProps {
@@ -333,8 +334,9 @@ interface NumberInputProps {
 export const Checkbox = (props: CheckboxProps) => {
   return (
     <div className={props.className}>
-      <label className="checkbox checkbox-text">
+      <label className={`checkbox checkbox-text${props.disabled ? " checkbox-disabled" : ""}`}>
         <input className="checkbox-input" type="checkbox" checked={props.value}
+               disabled={props.disabled}
                onChange={e => props.onChange(e.target.checked)}/>
         <span>{props.label}</span>
       </label>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -120,6 +120,11 @@ input[type="search"] {
     font-size: 18px;
 }
 
+.checkbox-disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
 .modifier-search-box {
     padding: 8px;
     width: 85%;

--- a/src/utils/SavedSettings.ts
+++ b/src/utils/SavedSettings.ts
@@ -194,6 +194,7 @@ export interface MapSettings {
   displayNightmareMods: boolean
   displayAffixBadges: boolean
   groupByAffix: boolean
+  tradeEightModOnly: boolean
   rarity: {
     normal: boolean
     magic: boolean
@@ -396,6 +397,7 @@ export const defaultSettings: SavedSettings = {
     displayNightmareMods: false,
     displayAffixBadges: false,
     groupByAffix: false,
+    tradeEightModOnly: false,
     rarity: {
       normal: true,
       magic: true,

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -3,9 +3,14 @@ import tradeStatIds from "../generated/mapmods/trade/TradeStatIdMatching.json";
 const WORKER_URL = "https://poe-trade-proxy.veiset.workers.dev";
 const TRADE_URL_BASE = "https://www.pathofexile.com/trade/search";
 
+interface StatFilter {
+  id: string;
+  value?: { min: number };
+}
+
 interface StatGroup {
   type: "and" | "not" | "count" | "if";
-  filters: { id: string }[];
+  filters: StatFilter[];
   value?: { min: number };
 }
 
@@ -17,6 +22,11 @@ export interface TradeSettings {
   packsize: string;
   itemRarity: string;
   regex: string;
+  eightModOnly: boolean;
+  corrupted: {
+    enabled: boolean;
+    include: boolean;
+  };
 }
 
 interface TradeQuery {
@@ -38,6 +48,12 @@ interface TradeQuery {
         filters: {
           rarity?: { option: string };
           category?: { option: string };
+        };
+      };
+      misc_filters?: {
+        disabled: boolean;
+        filters: {
+          corrupted?: { option: "true" | "false" };
         };
       };
     };
@@ -132,6 +148,13 @@ function buildTradeQuery(settings: TradeSettings): TradeQuery {
     }
   }
 
+  if (settings.eightModOnly) {
+    stats.push({
+      type: "and",
+      filters: [{ id: "pseudo.pseudo_number_of_affix_mods", value: { min: 8 } }],
+    });
+  }
+
   if (stats.length > 0) {
     query.query.stats = stats;
   }
@@ -146,6 +169,15 @@ function buildTradeQuery(settings: TradeSettings): TradeQuery {
       ...(mapIiq && { map_iiq: mapIiq }),
       ...(mapPacksize && { map_packsize: mapPacksize }),
       ...(mapIir && { map_iir: mapIir }),
+    };
+  }
+
+  if (settings.corrupted.enabled) {
+    query.query.filters.misc_filters = {
+      disabled: false,
+      filters: {
+        corrupted: { option: settings.corrupted.include ? "true" : "false" },
+      },
     };
   }
 


### PR DESCRIPTION
Addresses #358 — and while wiring it up, also makes the existing **Corrupted Map** include/exclude affect the trade URL (previously it was ignored on the trade side).

## Summary

- New checkbox **"Search for 8-mod maps only (Trade)"** above the Corrupted Map row. When ticked, the Trade URL adds the `pseudo.pseudo_number_of_affix_mods` filter with `min: 8`.
- Corrupted Map's existing **Include / Exclude** radios are now reflected in the trade URL's `misc_filters.corrupted` (`"true"` / `"false"`). When the parent checkbox is off, no filter is emitted.
- 8-mod is gated against Corrupted + Exclude (8-mod maps must be corrupted, so the combination is contradictory). The 8-mod checkbox greys out and the trade query suppresses the pseudo filter even if a stale persisted value is true.

## Out of scope

- T16-only was already addressed upstream (#377).
- The trade-type default ("Buyout" vs "In person") is being handled in #384.

## Screenshots

### How UI changes and starting point for trade
<img width="1312" height="502" alt="pr-screenshot-ui" src="https://github.com/user-attachments/assets/fc57b602-2d22-4413-8daf-7d26a712b060" />

### Resulting trade combined filters
<img width="1537" height="467" alt="pr-screenshot-trade" src="https://github.com/user-attachments/assets/c74ce0b5-1280-4464-85f3-952986a63f05" />

### Extra fix for trade for "Excluded" to work also with new 8-mod
<img width="524" height="112" alt="Zrzut ekranu 2026-05-05 073127" src="https://github.com/user-attachments/assets/41e1bbbe-2c43-42d7-a37f-0fe715137485" />

## Test plan

- [x] `npm test` — 5/5 pass
- [x] `npx tsc --noEmit` clean
- [x] Manual: tick 8-mod, click Trade → trade page shows `pseudo # Modifiers ≥ 8`
- [x] Manual: enable Corrupted + Exclude → 8-mod checkbox greys out
- [x] Manual: toggle Corrupted Include / Exclude → trade page shows `Misc → Corrupted = Yes` / `No` accordingly
- [x] Existing user profiles in localStorage missing `tradeEightModOnly` fall through to `false` via the existing deep-merge in `loadSettings`