### PR TITLE
feat(trade): wire map yield, quality, and unidentified into trade search

### DIFF
--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -45,10 +45,6 @@ const OptimizedMapMods = () => {
   const [tradeEightModOnly, setTradeEightModOnly] = useState(profile.map.tradeEightModOnly);
   const [tradeExcludeValdo, setTradeExcludeValdo] = useState(profile.map.tradeExcludeValdo);
   const [tradeExcludeShaperElder, setTradeExcludeShaperElder] = useState(profile.map.tradeExcludeShaperElder);
-  const [tradeMoreMaps, setTradeMoreMaps] = useState(profile.map.tradeMoreMaps);
-  const [tradeMoreCurrency, setTradeMoreCurrency] = useState(profile.map.tradeMoreCurrency);
-  const [tradeMoreScarabs, setTradeMoreScarabs] = useState(profile.map.tradeMoreScarabs);
-  const [tradeMoreDivinationCards, setTradeMoreDivinationCards] = useState(profile.map.tradeMoreDivinationCards);
   const eightModDisabled = corrupted.enabled && !corrupted.include;
 
   const [customTextStr, setCustomTextStr] = useState(profile.map.customText.value);
@@ -71,10 +67,9 @@ const OptimizedMapMods = () => {
         eightModOnly: tradeEightModOnly && !eightModDisabled,
         excludeValdo: tradeExcludeValdo,
         excludeShaperElder: tradeExcludeShaperElder,
-        moreMaps: tradeMoreMaps,
-        moreCurrency: tradeMoreCurrency,
-        moreScarabs: tradeMoreScarabs,
-        moreDivinationCards: tradeMoreDivinationCards,
+        mapDropChance,
+        quality,
+        anyQuality,
         corrupted,
       };
       const tradeResult = await openTradeSearch(settings);
@@ -111,10 +106,6 @@ const OptimizedMapMods = () => {
       tradeEightModOnly,
       tradeExcludeValdo,
       tradeExcludeShaperElder,
-      tradeMoreMaps,
-      tradeMoreCurrency,
-      tradeMoreScarabs,
-      tradeMoreDivinationCards,
       customText: {
         value: customTextStr,
         enabled: enableCustomText,
@@ -126,7 +117,7 @@ const OptimizedMapMods = () => {
       map: {...settings},
     });
     setResult(generateMapModRegex(settings, regex, profile.language));
-  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix, tradeEightModOnly, tradeExcludeValdo, tradeExcludeShaperElder, tradeMoreMaps, tradeMoreCurrency, tradeMoreScarabs, tradeMoreDivinationCards]);
+  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix, tradeEightModOnly, tradeExcludeValdo, tradeExcludeShaperElder]);
 
   const renderAffixTag = displayAffixBadges
     ? (token: Token<MapModsTokenOption>) => (
@@ -181,10 +172,6 @@ const OptimizedMapMods = () => {
           setTradeEightModOnly(defaultSettings.map.tradeEightModOnly);
           setTradeExcludeValdo(defaultSettings.map.tradeExcludeValdo);
           setTradeExcludeShaperElder(defaultSettings.map.tradeExcludeShaperElder);
-          setTradeMoreMaps(defaultSettings.map.tradeMoreMaps);
-          setTradeMoreCurrency(defaultSettings.map.tradeMoreCurrency);
-          setTradeMoreScarabs(defaultSettings.map.tradeMoreScarabs);
-          setTradeMoreDivinationCards(defaultSettings.map.tradeMoreDivinationCards);
         }}
       />
       {tradeMessage && (
@@ -207,7 +194,7 @@ const OptimizedMapMods = () => {
                     }>
           <NumberField id="quantity" label="Quantity of at least" value={quantity} onChange={setQuantity} trade/>
           <NumberField id="pack-size" label="Pack Size of at least" value={packsize} onChange={setPacksize} trade/>
-          <NumberField id="mapdrop" label="More maps of at least" value={mapDropChance} onChange={setMapDropChance}/>
+          <NumberField id="mapdrop" label="More maps of at least" value={mapDropChance} onChange={setMapDropChance} trade/>
           <NumberField id="itemRarity" label="Item rarity of at least" value={itemRarity} onChange={setItemRarity} trade/>
         </FilterCard>
         
@@ -246,15 +233,15 @@ const OptimizedMapMods = () => {
             <NumberField id="qregular" label="Quality of" value={quality.regular} primary
                          onChange={(v) => setQuality({...quality, regular: v})}/>
             <NumberField id="qpacksize" label="• Pack size" value={quality.packSize}
-                         onChange={(v) => setQuality({...quality, packSize: v})}/>
+                         onChange={(v) => setQuality({...quality, packSize: v})} trade/>
             <NumberField id="qrarity" label="• Rarity" value={quality.rarity}
-                         onChange={(v) => setQuality({...quality, rarity: v})}/>
+                         onChange={(v) => setQuality({...quality, rarity: v})} trade/>
             <NumberField id="qcurrency" label="• Currency" value={quality.currency}
-                         onChange={(v) => setQuality({...quality, currency: v})}/>
+                         onChange={(v) => setQuality({...quality, currency: v})} trade/>
             <NumberField id="qdiv" label="• Divination" value={quality.divination}
-                         onChange={(v) => setQuality({...quality, divination: v})}/>
+                         onChange={(v) => setQuality({...quality, divination: v})} trade/>
             <NumberField id="qscarab" label="• Scarab" value={quality.scarab}
-                         onChange={(v) => setQuality({...quality, scarab: v})}/>
+                         onChange={(v) => setQuality({...quality, scarab: v})} trade/>
           </div>
           <Checkbox label="Match any of the quality types (disable to match ALL selected qualities)"
                     value={anyQuality}
@@ -272,14 +259,6 @@ const OptimizedMapMods = () => {
           <Checkbox label={<>Exclude Shaper/Elder influenced maps<TradeAsterisk/></>}
                     value={tradeExcludeShaperElder}
                     onChange={setTradeExcludeShaperElder}/>
-          <NumberField id="trade-more-maps" label="More Maps % of at least"
-                       value={tradeMoreMaps} onChange={setTradeMoreMaps} trade/>
-          <NumberField id="trade-more-currency" label="More Currency % of at least"
-                       value={tradeMoreCurrency} onChange={setTradeMoreCurrency} trade/>
-          <NumberField id="trade-more-scarabs" label="More Scarabs % of at least"
-                       value={tradeMoreScarabs} onChange={setTradeMoreScarabs} trade/>
-          <NumberField id="trade-more-cards" label="More Divination Cards % of at least"
-                       value={tradeMoreDivinationCards} onChange={setTradeMoreDivinationCards} trade/>
         </FilterCard>
 
       </div>

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -45,6 +45,10 @@ const OptimizedMapMods = () => {
   const [tradeEightModOnly, setTradeEightModOnly] = useState(profile.map.tradeEightModOnly);
   const [tradeExcludeValdo, setTradeExcludeValdo] = useState(profile.map.tradeExcludeValdo);
   const [tradeExcludeShaperElder, setTradeExcludeShaperElder] = useState(profile.map.tradeExcludeShaperElder);
+  const [tradeMoreMaps, setTradeMoreMaps] = useState(profile.map.tradeMoreMaps);
+  const [tradeMoreCurrency, setTradeMoreCurrency] = useState(profile.map.tradeMoreCurrency);
+  const [tradeMoreScarabs, setTradeMoreScarabs] = useState(profile.map.tradeMoreScarabs);
+  const [tradeMoreDivinationCards, setTradeMoreDivinationCards] = useState(profile.map.tradeMoreDivinationCards);
   const eightModDisabled = corrupted.enabled && !corrupted.include;
 
   const [customTextStr, setCustomTextStr] = useState(profile.map.customText.value);
@@ -67,6 +71,10 @@ const OptimizedMapMods = () => {
         eightModOnly: tradeEightModOnly && !eightModDisabled,
         excludeValdo: tradeExcludeValdo,
         excludeShaperElder: tradeExcludeShaperElder,
+        moreMaps: tradeMoreMaps,
+        moreCurrency: tradeMoreCurrency,
+        moreScarabs: tradeMoreScarabs,
+        moreDivinationCards: tradeMoreDivinationCards,
         corrupted,
       };
       const tradeResult = await openTradeSearch(settings);
@@ -103,6 +111,10 @@ const OptimizedMapMods = () => {
       tradeEightModOnly,
       tradeExcludeValdo,
       tradeExcludeShaperElder,
+      tradeMoreMaps,
+      tradeMoreCurrency,
+      tradeMoreScarabs,
+      tradeMoreDivinationCards,
       customText: {
         value: customTextStr,
         enabled: enableCustomText,
@@ -114,7 +126,7 @@ const OptimizedMapMods = () => {
       map: {...settings},
     });
     setResult(generateMapModRegex(settings, regex, profile.language));
-  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix, tradeEightModOnly, tradeExcludeValdo, tradeExcludeShaperElder]);
+  }, [result, rarity, corrupted, unidentified, quality, anyQuality, itemRarity, selectedBadIds, selectedGoodIds, modGrouping, quantity, packsize, optimizeQuant, optimizePacksize, optimizeQuality, customTextStr, enableCustomText, regex, mapDropChance, displayNightmareMods, displayAffixBadges, groupByAffix, tradeEightModOnly, tradeExcludeValdo, tradeExcludeShaperElder, tradeMoreMaps, tradeMoreCurrency, tradeMoreScarabs, tradeMoreDivinationCards]);
 
   const renderAffixTag = displayAffixBadges
     ? (token: Token<MapModsTokenOption>) => (
@@ -169,6 +181,10 @@ const OptimizedMapMods = () => {
           setTradeEightModOnly(defaultSettings.map.tradeEightModOnly);
           setTradeExcludeValdo(defaultSettings.map.tradeExcludeValdo);
           setTradeExcludeShaperElder(defaultSettings.map.tradeExcludeShaperElder);
+          setTradeMoreMaps(defaultSettings.map.tradeMoreMaps);
+          setTradeMoreCurrency(defaultSettings.map.tradeMoreCurrency);
+          setTradeMoreScarabs(defaultSettings.map.tradeMoreScarabs);
+          setTradeMoreDivinationCards(defaultSettings.map.tradeMoreDivinationCards);
         }}
       />
       {tradeMessage && (
@@ -256,6 +272,14 @@ const OptimizedMapMods = () => {
           <Checkbox label={<>Exclude Shaper/Elder influenced maps<TradeAsterisk/></>}
                     value={tradeExcludeShaperElder}
                     onChange={setTradeExcludeShaperElder}/>
+          <NumberField id="trade-more-maps" label="More Maps % of at least"
+                       value={tradeMoreMaps} onChange={setTradeMoreMaps} trade/>
+          <NumberField id="trade-more-currency" label="More Currency % of at least"
+                       value={tradeMoreCurrency} onChange={setTradeMoreCurrency} trade/>
+          <NumberField id="trade-more-scarabs" label="More Scarabs % of at least"
+                       value={tradeMoreScarabs} onChange={setTradeMoreScarabs} trade/>
+          <NumberField id="trade-more-cards" label="More Divination Cards % of at least"
+                       value={tradeMoreDivinationCards} onChange={setTradeMoreDivinationCards} trade/>
         </FilterCard>
 
       </div>

--- a/src/pages/maps/OptimizedMapMods.tsx
+++ b/src/pages/maps/OptimizedMapMods.tsx
@@ -71,6 +71,7 @@ const OptimizedMapMods = () => {
         quality,
         anyQuality,
         corrupted,
+        unidentified,
       };
       const tradeResult = await openTradeSearch(settings);
       if (tradeResult.success) {
@@ -200,7 +201,7 @@ const OptimizedMapMods = () => {
         
         <FilterCard title="Map State">
           <div className={`mm-state-row${corrupted.enabled ? "" : " mm-state-row-off"}`}>
-            <Checkbox label="Filter corrupted" value={corrupted.enabled}
+            <Checkbox label={<>Filter corrupted<TradeAsterisk/></>} value={corrupted.enabled}
                       onChange={() => setCorrupted({...corrupted, enabled: !corrupted.enabled})}/>
             <IncludeExcludeToggle name="corrupted" include={corrupted.include}
                                   setInclude={(v) => setCorrupted({...corrupted, include: v})}/>
@@ -216,7 +217,7 @@ const OptimizedMapMods = () => {
                                   setInclude={(v) => setRarity({...rarity, include: v})}/>
           </div>
           <div className={`mm-state-row${unidentified.enabled ? "" : " mm-state-row-off"}`}>
-            <Checkbox label="Filter unidentified" value={unidentified.enabled}
+            <Checkbox label={<>Filter unidentified<TradeAsterisk/></>} value={unidentified.enabled}
                       onChange={() => setUnidentified({...unidentified, enabled: !unidentified.enabled})}/>
             <IncludeExcludeToggle name="unidentified" include={unidentified.include}
                                   setInclude={(v) => setUnidentified({...unidentified, include: v})}/>

--- a/src/utils/SavedSettings.ts
+++ b/src/utils/SavedSettings.ts
@@ -210,10 +210,6 @@ export interface MapSettings {
   tradeEightModOnly: boolean;
   tradeExcludeValdo: boolean;
   tradeExcludeShaperElder: boolean;
-  tradeMoreMaps: string;
-  tradeMoreCurrency: string;
-  tradeMoreScarabs: string;
-  tradeMoreDivinationCards: string;
   rarity: {
     normal: boolean;
     magic: boolean;
@@ -417,10 +413,6 @@ export const defaultSettings: SavedSettings = {
     tradeEightModOnly: false,
     tradeExcludeValdo: true,
     tradeExcludeShaperElder: true,
-    tradeMoreMaps: "",
-    tradeMoreCurrency: "",
-    tradeMoreScarabs: "",
-    tradeMoreDivinationCards: "",
     rarity: {
       normal: true,
       magic: true,

--- a/src/utils/SavedSettings.ts
+++ b/src/utils/SavedSettings.ts
@@ -210,6 +210,10 @@ export interface MapSettings {
   tradeEightModOnly: boolean;
   tradeExcludeValdo: boolean;
   tradeExcludeShaperElder: boolean;
+  tradeMoreMaps: string;
+  tradeMoreCurrency: string;
+  tradeMoreScarabs: string;
+  tradeMoreDivinationCards: string;
   rarity: {
     normal: boolean;
     magic: boolean;
@@ -413,6 +417,10 @@ export const defaultSettings: SavedSettings = {
     tradeEightModOnly: false,
     tradeExcludeValdo: true,
     tradeExcludeShaperElder: true,
+    tradeMoreMaps: "",
+    tradeMoreCurrency: "",
+    tradeMoreScarabs: "",
+    tradeMoreDivinationCards: "",
     rarity: {
       normal: true,
       magic: true,

--- a/src/utils/TradeUrlBuilder.test.ts
+++ b/src/utils/TradeUrlBuilder.test.ts
@@ -1,0 +1,133 @@
+import {buildTradeQuery, TradeSettings} from "./TradeUrlBuilder";
+
+const baseSettings = (overrides: Partial<TradeSettings> = {}): TradeSettings => ({
+  badIds: [],
+  goodIds: [],
+  allGoodMods: true,
+  quantity: "",
+  packsize: "",
+  itemRarity: "",
+  regex: "",
+  eightModOnly: false,
+  excludeValdo: false,
+  excludeShaperElder: false,
+  mapDropChance: "",
+  quality: {currency: "", divination: "", scarab: "", rarity: "", packSize: ""},
+  anyQuality: false,
+  corrupted: {enabled: false, include: true},
+  unidentified: {enabled: false, include: true},
+  ...overrides,
+});
+
+describe("buildTradeQuery", () => {
+  describe("parseMinFilter boundaries (via mapDropChance)", () => {
+    test.each([
+      ["empty string", ""],
+      ["zero", "0"],
+      ["negative", "-5"],
+      ["non-numeric", "abc"],
+    ])("does not emit a stat group for %s", (_label, value) => {
+      const q = buildTradeQuery(baseSettings({mapDropChance: value}));
+      expect(q.query.stats ?? []).toEqual([]);
+    });
+
+    test("positive integer emits a stat group with min", () => {
+      const q = buildTradeQuery(baseSettings({mapDropChance: "30"}));
+      expect(q.query.stats).toEqual([
+        {
+          type: "and",
+          filters: [{id: "pseudo.pseudo_map_more_map_drops", value: {min: 30}}],
+        },
+      ]);
+    });
+  });
+
+  describe("quality + anyQuality group selection", () => {
+    test("one quality field with anyQuality=true uses 'and' (not a 1-filter count)", () => {
+      const q = buildTradeQuery(
+        baseSettings({
+          anyQuality: true,
+          quality: {currency: "5", divination: "", scarab: "", rarity: "", packSize: ""},
+        }),
+      );
+      expect(q.query.stats).toEqual([
+        {
+          type: "and",
+          filters: [{id: "pseudo.pseudo_map_quality_currency", value: {min: 5}}],
+        },
+      ]);
+    });
+
+    test("multiple quality fields with anyQuality=true use 'count' min:1", () => {
+      const q = buildTradeQuery(
+        baseSettings({
+          anyQuality: true,
+          quality: {currency: "5", divination: "3", scarab: "", rarity: "", packSize: ""},
+        }),
+      );
+      expect(q.query.stats).toEqual([
+        {
+          type: "count",
+          filters: [
+            {id: "pseudo.pseudo_map_quality_currency", value: {min: 5}},
+            {id: "pseudo.pseudo_map_quality_cards", value: {min: 3}},
+          ],
+          value: {min: 1},
+        },
+      ]);
+    });
+
+    test("multiple quality fields with anyQuality=false use 'and'", () => {
+      const q = buildTradeQuery(
+        baseSettings({
+          anyQuality: false,
+          quality: {currency: "5", divination: "3", scarab: "", rarity: "", packSize: ""},
+        }),
+      );
+      expect(q.query.stats).toEqual([
+        {
+          type: "and",
+          filters: [
+            {id: "pseudo.pseudo_map_quality_currency", value: {min: 5}},
+            {id: "pseudo.pseudo_map_quality_cards", value: {min: 3}},
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe("unidentified.include inversion", () => {
+    test("enabled + include=true emits identified='false' (show only unidentified)", () => {
+      const q = buildTradeQuery(baseSettings({unidentified: {enabled: true, include: true}}));
+      expect(q.query.filters.misc_filters?.filters.identified).toEqual({option: "false"});
+    });
+
+    test("enabled + include=false emits identified='true' (show only identified)", () => {
+      const q = buildTradeQuery(baseSettings({unidentified: {enabled: true, include: false}}));
+      expect(q.query.filters.misc_filters?.filters.identified).toEqual({option: "true"});
+    });
+
+    test("disabled emits no identified key (and no misc_filters block at all)", () => {
+      const q = buildTradeQuery(baseSettings({unidentified: {enabled: false, include: true}}));
+      expect(q.query.filters.misc_filters).toBeUndefined();
+    });
+  });
+
+  test("misc_filters merges corrupted, unidentified, and excludeValdo", () => {
+    const q = buildTradeQuery(
+      baseSettings({
+        corrupted: {enabled: true, include: false},
+        unidentified: {enabled: true, include: false},
+        excludeValdo: true,
+      }),
+    );
+    expect(q.query.filters.misc_filters).toEqual({
+      disabled: false,
+      filters: {
+        corrupted: {option: "false"},
+        identified: {option: "true"},
+        foil_variation: {option: "none"},
+      },
+    });
+  });
+});

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -25,10 +25,15 @@ export interface TradeSettings {
   eightModOnly: boolean;
   excludeValdo: boolean;
   excludeShaperElder: boolean;
-  moreMaps: string;
-  moreCurrency: string;
-  moreScarabs: string;
-  moreDivinationCards: string;
+  mapDropChance: string;
+  quality: {
+    currency: string;
+    divination: string;
+    scarab: string;
+    rarity: string;
+    packSize: string;
+  };
+  anyQuality: boolean;
   corrupted: {
     enabled: boolean;
     include: boolean;
@@ -162,17 +167,30 @@ function buildTradeQuery(settings: TradeSettings): TradeQuery {
     });
   }
 
-  const yieldFilters: StatFilter[] = [];
-  const pushYield = (raw: string, id: string) => {
+  const mapDropMin = parseMinFilter(settings.mapDropChance);
+  if (mapDropMin) {
+    stats.push({
+      type: "and",
+      filters: [{ id: "pseudo.pseudo_map_more_map_drops", value: mapDropMin }],
+    });
+  }
+
+  const qualityFilters: StatFilter[] = [];
+  const pushQuality = (raw: string, id: string) => {
     const min = parseMinFilter(raw);
-    if (min) yieldFilters.push({ id, value: min });
+    if (min) qualityFilters.push({ id, value: min });
   };
-  pushYield(settings.moreMaps, "pseudo.pseudo_map_more_map_drops");
-  pushYield(settings.moreCurrency, "pseudo.pseudo_map_more_currency_drops");
-  pushYield(settings.moreScarabs, "pseudo.pseudo_map_more_scarab_drops");
-  pushYield(settings.moreDivinationCards, "pseudo.pseudo_map_more_card_drops");
-  if (yieldFilters.length > 0) {
-    stats.push({ type: "and", filters: yieldFilters });
+  pushQuality(settings.quality.currency, "pseudo.pseudo_map_quality_currency");
+  pushQuality(settings.quality.divination, "pseudo.pseudo_map_quality_cards");
+  pushQuality(settings.quality.scarab, "pseudo.pseudo_map_quality_scarabs");
+  pushQuality(settings.quality.rarity, "pseudo.pseudo_map_quality_rarity");
+  pushQuality(settings.quality.packSize, "pseudo.pseudo_map_quality_pack_size");
+  if (qualityFilters.length > 0) {
+    if (settings.anyQuality && qualityFilters.length > 1) {
+      stats.push({ type: "count", filters: qualityFilters, value: { min: 1 } });
+    } else {
+      stats.push({ type: "and", filters: qualityFilters });
+    }
   }
 
   if (settings.excludeShaperElder) {

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -25,6 +25,10 @@ export interface TradeSettings {
   eightModOnly: boolean;
   excludeValdo: boolean;
   excludeShaperElder: boolean;
+  moreMaps: string;
+  moreCurrency: string;
+  moreScarabs: string;
+  moreDivinationCards: string;
   corrupted: {
     enabled: boolean;
     include: boolean;
@@ -156,6 +160,19 @@ function buildTradeQuery(settings: TradeSettings): TradeQuery {
       type: "and",
       filters: [{ id: "pseudo.pseudo_number_of_affix_mods", value: { min: 8 } }],
     });
+  }
+
+  const yieldFilters: StatFilter[] = [];
+  const pushYield = (raw: string, id: string) => {
+    const min = parseMinFilter(raw);
+    if (min) yieldFilters.push({ id, value: min });
+  };
+  pushYield(settings.moreMaps, "pseudo.pseudo_map_more_map_drops");
+  pushYield(settings.moreCurrency, "pseudo.pseudo_map_more_currency_drops");
+  pushYield(settings.moreScarabs, "pseudo.pseudo_map_more_scarab_drops");
+  pushYield(settings.moreDivinationCards, "pseudo.pseudo_map_more_card_drops");
+  if (yieldFilters.length > 0) {
+    stats.push({ type: "and", filters: yieldFilters });
   }
 
   if (settings.excludeShaperElder) {

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -38,6 +38,10 @@ export interface TradeSettings {
     enabled: boolean;
     include: boolean;
   };
+  unidentified: {
+    enabled: boolean;
+    include: boolean;
+  };
 }
 
 interface TradeQuery {
@@ -65,6 +69,7 @@ interface TradeQuery {
         disabled: boolean;
         filters: {
           corrupted?: { option: "true" | "false" };
+          identified?: { option: "true" | "false" };
           foil_variation?: { option: "none" };
         };
       };
@@ -217,12 +222,15 @@ function buildTradeQuery(settings: TradeSettings): TradeQuery {
     };
   }
 
-  if (settings.corrupted.enabled || settings.excludeValdo) {
+  if (settings.corrupted.enabled || settings.unidentified.enabled || settings.excludeValdo) {
     query.query.filters.misc_filters = {
       disabled: false,
       filters: {
         ...(settings.corrupted.enabled && {
           corrupted: { option: settings.corrupted.include ? "true" : "false" },
+        }),
+        ...(settings.unidentified.enabled && {
+          identified: { option: settings.unidentified.include ? "false" : "true" },
         }),
         ...(settings.excludeValdo && { foil_variation: { option: "none" } }),
       },

--- a/src/utils/TradeUrlBuilder.ts
+++ b/src/utils/TradeUrlBuilder.ts
@@ -1,4 +1,5 @@
 import tradeStatIds from "../generated/mapmods/trade/TradeStatIdMatching.json";
+import {MapSettings} from "./SavedSettings";
 
 const WORKER_URL = "https://poe-trade-proxy.veiset.workers.dev";
 const TRADE_URL_BASE = "https://www.pathofexile.com/trade/search";
@@ -26,13 +27,7 @@ export interface TradeSettings {
   excludeValdo: boolean;
   excludeShaperElder: boolean;
   mapDropChance: string;
-  quality: {
-    currency: string;
-    divination: string;
-    scarab: string;
-    rarity: string;
-    packSize: string;
-  };
+  quality: Omit<MapSettings["quality"], "regular">;
   anyQuality: boolean;
   corrupted: {
     enabled: boolean;
@@ -126,7 +121,7 @@ function parseMinFilter(value: string): { min: number } | undefined {
   return !isNaN(num) && num > 0 ? { min: num } : undefined;
 }
 
-function buildTradeQuery(settings: TradeSettings): TradeQuery {
+export function buildTradeQuery(settings: TradeSettings): TradeQuery {
   const query: TradeQuery = {
     query: {
       status: { option: "securable" },


### PR DESCRIPTION
Closes #394.

Wires existing form fields on the Optimized Map Modifiers page into the trade search query, rather than introducing duplicate inputs. Each wired field gets the `*` marker.

## Wired fields

### Quantity & Yield card
| Field | Pseudo stat |
| --- | --- |
| More maps of at least | `pseudo.pseudo_map_more_map_drops` |

### Quality card (5 fields)
| Field | Pseudo stat |
| --- | --- |
| • Currency | `pseudo.pseudo_map_quality_currency` |
| • Divination | `pseudo.pseudo_map_quality_cards` |
| • Scarab | `pseudo.pseudo_map_quality_scarabs` |
| • Rarity | `pseudo.pseudo_map_quality_rarity` |
| • Pack size | `pseudo.pseudo_map_quality_pack_size` |

The existing **Match any of the quality types** toggle now also affects trade: with ≥2 quality fields filled and the toggle on, the trade query uses a `count` stat group with `min: 1` (= OR); otherwise an `and` group (= AND). One filled field always uses `and` to avoid degenerate single-filter `count` groups.

The base "Quality of" (`quality.regular`) field stays regex-only — there's no per-item pseudo stat for total map quality, and modelling it via weighted-sum didn't seem worth the complexity here.

### Map State card
| Field | Trade target |
| --- | --- |
| Filter unidentified | `misc_filters.filters.identified.option` |

Inverted semantics: `include` means "show only unidentified" → `identified: "false"`; exclude → `"true"`; disabled → no key emitted.

"Filter corrupted" was already trade-wired but missing its `*` marker; that's now consistent with the rest of the page.

## Other

- `TradeSettings.quality` is declared as `Omit<MapSettings["quality"], "regular">` so future renames in `MapSettings` will break the compiler at the trade boundary instead of silently desynchronising.
- Empty inputs are skipped throughout (handled by the existing `parseMinFilter` helper).
- Existing saved profiles deep-merge against defaults via `loadSettings`, so no migration needed.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm test` — 35 tests pass (12 new in `TradeUrlBuilder.test.ts` covering parseMinFilter boundaries, anyQuality and-vs-count toggle, unidentified inversion, and misc-filters merge)
- [x] Manually verify the produced trade URL on the deployed site with various combinations
