### PR TITLE
fix(tattoo): replace Shieldbearer token that collides with help text

### DIFF
--- a/src/generated/GeneratedTattoo.test.ts
+++ b/src/generated/GeneratedTattoo.test.ts
@@ -1,0 +1,37 @@
+import {tattooRegex} from "./GeneratedTattoo";
+
+// Help text rendered on every tattoo in-game. Source: screenshot in
+// https://github.com/veiset/poe-vendor-string/issues/338.
+const SHARED_HELP_TEXT =
+  "Right click this item then left click an allocated Passive Skill. " +
+  "Maximum 50 Tattoos. Shift click to unstack.";
+
+const fullSearchableText = (t: {tattoo: string; description: string}) =>
+  `${t.tattoo}\n${t.description}\n${SHARED_HELP_TEXT}`;
+
+describe("tattoo regex invariants (#338)", () => {
+  test("no tattoo regex matches the shared in-game help text", () => {
+    const collisions: string[] = [];
+    for (const t of tattooRegex) {
+      const re = new RegExp(t.regex, "i");
+      if (re.test(SHARED_HELP_TEXT)) {
+        collisions.push(`${t.tattoo} (regex="${t.regex}") matches shared help text`);
+      }
+    }
+    expect(collisions).toEqual([]);
+  });
+
+  test("no tattoo regex matches any other tattoo's full text", () => {
+    const collisions: string[] = [];
+    for (const target of tattooRegex) {
+      const re = new RegExp(target.regex, "i");
+      const others = tattooRegex.filter((o) => o !== target && re.test(fullSearchableText(o)));
+      if (others.length > 0) {
+        collisions.push(
+          `${target.tattoo} (regex="${target.regex}") matches ${others.length} other tattoo(s): ${others.slice(0, 3).map((o) => o.tattoo).join(", ")}`,
+        );
+      }
+    }
+    expect(collisions).toEqual([]);
+  });
+});

--- a/src/generated/GeneratedTattoo.ts
+++ b/src/generated/GeneratedTattoo.ts
@@ -35,7 +35,7 @@ export const tattooRegex: TattooRegex[] = [
     { tattoo: "Tattoo of the Tukohama Warrior", description: "Melee Hits which Stun have 5% chance to Fortify", regex: "ify" },
     { tattoo: "Tattoo of the Valako Scout", description: "10% reduced Effect of Shock on you", regex: "f Sh" },
     { tattoo: "Tattoo of the Valako Shaman", description: "5% chance to Shock", regex: "to Sh" },
-    { tattoo: "Tattoo of the Valako Shieldbearer", description: "+1% Chance to Block Attack Damage", regex: "ck A" },
+    { tattoo: "Tattoo of the Valako Shieldbearer", description: "+1% Chance to Block Attack Damage", regex: "k At" },
     { tattoo: "Tattoo of the Valako Stormrider", description: "+6% to Lightning Resistance", regex: "orm" },
     { tattoo: "Tattoo of the Valako Warrior", description: "5% increased Lightning Damage", regex: "g d" },
     { tattoo: "Journey Tattoo of the Mind", description: "+30 to maximum Mana", regex: "30 t" },


### PR DESCRIPTION
Closes #338.

## Bug

PoE renders the same help-text block on every tattoo:

> Right click this item then left click an allocated Passive Skill. Maximum 50 Tattoos. Shift click to unstack.

`Tattoo of the Valako Shieldbearer` had the regex token `"ck A"`, which is intended to match `Blo`**`ck A`**`ttack` in its description (`+1% Chance to Block Attack Damage`). Unfortunately `"ck A"` also matches `left cli`**`ck a`**`n` in the shared help text — so selecting Shieldbearer in the tattoo regex builder highlighted **all 53 other tattoos** in the stash, not just Shieldbearer.

Audited every tattoo regex against the help text and against every other tattoo's full searchable text — Shieldbearer was the only real collision in the dataset.

## Fix

Swap the token to `"k At"`: still uniquely matches `Bloc`**`k At`**`tack` in Shieldbearer's description, doesn't match `left click an`, doesn't collide with any other tattoo. One-character data change.

> The reporter also mentioned `"ns"` from "Hinekora warrior" — the actual mod with `"ns "` is `Tattoo of the Hinekora Warmonger`, and its regex doesn't match the visible help text in the screenshot. If a second collision is still present we'd need an updated repro / screenshot.

## Test plan

- [x] Added `src/generated/GeneratedTattoo.test.ts` with two invariants over the full dataset — no tattoo regex matches the shared help text, no tattoo regex matches any other tattoo's full text. Reverting the data fix makes both tests fail naming Shieldbearer + its 52 collateral collisions, so the tests are actually load-bearing.
- [x] `npm test` — 25 tests pass
- [x] `tsc --noEmit` clean
- [ ] Manual in-game verification with Shieldbearer + neighbours